### PR TITLE
Fix remaining runtime bugs and improve error handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const initConfig = () => {
     stageHeight: 384,
     canvasWidth: 672,
     canvasHeight: 384,
+    recursionLimit: 1000,
   };
 };
 

--- a/src/errors/InvalidTypeError.ts
+++ b/src/errors/InvalidTypeError.ts
@@ -14,8 +14,7 @@ class InvalidTypeError extends Error {
     scopes: T_scope[],
     options: { trace?: A_ANY[]; cause?: unknown } = {},
   ) {
-    super("InvalidTypeError", { cause: options.cause });
-    this.message = message;
+    super(message, { cause: options.cause });
     this.ASTName = ast.type;
     this.ast = ast;
     this.scopes = scopes;

--- a/src/errors/InvalidTypeError.ts
+++ b/src/errors/InvalidTypeError.ts
@@ -7,17 +7,19 @@ class InvalidTypeError extends Error {
   ASTName: string;
   ast: A_ANY;
   scopes: T_scope[];
+  trace?: A_ANY[];
   constructor(
     message: string,
     ast: A_ANY,
     scopes: T_scope[],
-    options: { [key: string]: unknown } = {},
+    options: { trace?: A_ANY[]; cause?: unknown } = {},
   ) {
-    super("InvalidTypeError", options);
+    super("InvalidTypeError", { cause: options.cause });
     this.message = message;
     this.ASTName = ast.type;
     this.ast = ast;
     this.scopes = scopes;
+    this.trace = options.trace;
   }
 }
 InvalidTypeError.prototype.name = "InvalidTypeError";

--- a/src/errors/NotImplementedError.ts
+++ b/src/errors/NotImplementedError.ts
@@ -10,9 +10,9 @@ class NotImplementedError extends Error {
   constructor(
     ast: A_ANY,
     scopes: T_scope[],
-    options: { [key: string]: unknown } = {},
+    options: { cause?: unknown } = {},
   ) {
-    super("NotImplementedError", options);
+    super("NotImplementedError", { cause: options.cause });
     this.ASTName = ast.type;
     this.ast = ast;
     this.scopes = scopes;

--- a/src/errors/TooMuchRecursionError.ts
+++ b/src/errors/TooMuchRecursionError.ts
@@ -10,9 +10,9 @@ class TooMuchRecursionError extends Error {
   constructor(
     ast: A_ANY,
     scopes: T_scope[],
-    options: { [key: string]: unknown } = {},
+    options: { cause?: unknown } = {},
   ) {
-    super("TooMuchRecursionError", options);
+    super("TooMuchRecursionError", { cause: options.cause });
     this.ASTName = ast.type;
     this.ast = ast;
     this.scopes = scopes;

--- a/src/errors/TooMuchRecursionError.ts
+++ b/src/errors/TooMuchRecursionError.ts
@@ -1,7 +1,7 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 
 /**
- * 未実装の関数や機能を呼び出したときに発生するエラー
+ * 再帰の深さが許容される上限を超えた際に発生するエラー
  */
 class TooMuchRecursionError extends Error {
   ASTName: string;

--- a/src/functions/while_kari.ts
+++ b/src/functions/while_kari.ts
@@ -20,7 +20,7 @@ const processWhileKari: IrFunction = (
     return;
   }
   let loopCount = 0;
-  while (execute(script.arguments[0], scopes, trace) && loopCount++ < 10000) {
+  while (loopCount++ < 10000 && execute(script.arguments[0], scopes, trace)) {
     execute(script.arguments[1], scopes, trace);
   }
 };

--- a/src/functions/while_kari.ts
+++ b/src/functions/while_kari.ts
@@ -20,7 +20,7 @@ const processWhileKari: IrFunction = (
     return;
   }
   let loopCount = 0;
-  while (execute(script.arguments[0], scopes, trace) && loopCount++ <= 10000) {
+  while (execute(script.arguments[0], scopes, trace) && loopCount++ < 10000) {
     execute(script.arguments[1], scopes, trace);
   }
 };

--- a/src/processors/MemberExpression.ts
+++ b/src/processors/MemberExpression.ts
@@ -1,6 +1,7 @@
 import type { A_ANY, A_MemberExpression, T_scope } from "@/@types/ast";
 import type { definedFunction } from "@/@types/function";
 import { execute, getName } from "@/context";
+import { InvalidTypeError } from "@/errors/InvalidTypeError";
 import { NotImplementedError } from "@/errors/NotImplementedError";
 import { processCallExpression } from "@/processors/CallExpression";
 import typeGuard from "@/typeGuard";
@@ -17,13 +18,11 @@ const processMemberExpression = (
 ) => {
   const left = execute(script.object, scopes, trace);
   if (left === undefined) {
-    console.error(
-      "[member expression] left is undefined",
+    throw new InvalidTypeError(
+      "Cannot access property of undefined",
       script,
       scopes,
-      trace,
     );
-    return;
   }
   const right = (
     script.computed

--- a/src/processors/MemberExpression.ts
+++ b/src/processors/MemberExpression.ts
@@ -22,6 +22,7 @@ const processMemberExpression = (
       "Cannot access property of undefined",
       script,
       scopes,
+      { trace },
     );
   }
   const right = (

--- a/src/processors/MemberExpression.ts
+++ b/src/processors/MemberExpression.ts
@@ -17,9 +17,9 @@ const processMemberExpression = (
   trace: A_ANY[],
 ) => {
   const left = execute(script.object, scopes, trace);
-  if (left === undefined) {
+  if (left == null) {
     throw new InvalidTypeError(
-      "Cannot access property of undefined",
+      `Cannot access property of ${left === null ? "null" : "undefined"}`,
       script,
       scopes,
       { trace },

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -20,7 +20,7 @@ const assign = (
   try {
     if (typeGuard.Identifier(target)) {
       for (const scope of scopes) {
-        if (scope[target.name] !== undefined) {
+        if (Object.hasOwn(scope, target.name)) {
           scope[target.name] = value;
           return;
         }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -19,7 +19,7 @@ const format = <T extends "boolean" | "number" | "string">(
   to: T,
 ): Map[T] => {
   const formatFunc = resolvePrototype(getType(value), funcMap[to]);
-  if (!formatFunc) throw new Error();
+  if (!formatFunc) throw new Error(`Cannot convert ${getType(value)} to ${to}`);
   return formatFunc({} as A_CallExpression, [], value, []) as Map[T];
 };
 

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -1,5 +1,4 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
-import { resultHook } from "@/context";
 import typeGuard from "@/typeGuard";
 
 /**
@@ -12,8 +11,8 @@ const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
   try {
     if (typeGuard.Identifier(script)) {
       for (const scope of scopes) {
-        if (scope[script.name] !== undefined) {
-          return processResolveHook(scope, script.name);
+        if (Object.hasOwn(scope, script.name)) {
+          return scope[script.name];
         }
       }
     }
@@ -23,15 +22,6 @@ const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
     }
   }
   return undefined;
-};
-
-const processResolveHook = (scope: T_scope, name: string) => {
-  let value = scope[name];
-  for (const hook of resultHook) {
-    value = hook(value);
-  }
-  scope[name] = value;
-  return value;
 };
 
 export { resolve };


### PR DESCRIPTION
## Summary
- **resolve.ts のスコープ変異を除去**: 変数の読み取り操作（`resolve`）でスコープ内の値が書き換わっていた問題を修正。`processResolveHook` がスコープを変更していたため、hook が冪等でない場合に同じ変数を2回参照すると異なる結果になっていた
- **resultHook の二重適用を解消**: `resolve` と `executor` の両方で `resultHook` が適用されていたため、変数参照時に hook が2回適用される問題を修正。`resolve` 側の hook 適用を削除し `executor` に一元化
- **スコープ検索で `Object.hasOwn` を使用**: `resolve.ts` / `assign.ts` で `!== undefined` による判定を `Object.hasOwn` に変更。明示的に `undefined` が代入された変数が正しく検出されるように修正
- **MemberExpression の silent failure を修正**: left が `undefined` の場合に `console.error` + `return undefined` だったのを `InvalidTypeError` をスローするよう変更
- **recursionLimit のデフォルト値を設定**: `config.ts` に `recursionLimit: 1000` を追加し、無限再帰によるスタックオーバーフローを防止
- **format.ts のエラーメッセージ追加**: 型変換失敗時に空の `Error()` ではなく、変換元・変換先の型情報を含むメッセージを出力
- **while_kari のループ上限を統一**: `functions/while_kari.ts` の `<= 10000` を `< 10000` に変更し、`prototype/Value/while_kari.ts` と一致させた

## Test plan
- [x] 既存テスト63件がすべてパス (`pnpm test`)
- [x] ビルド成功 (`pnpm run build`)
- [x] pre-commit hook (lint, test, typecheck) パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable recursion limit.

* **Bug Fixes**
  * Fixed loop iteration boundary to stop at the intended limit.
  * Converted silent member-access failures into explicit thrown errors.
  * Adjusted identifier assignment and resolution to respect own-property presence reliably.

* **Improvements**
  * More informative error messages and enriched error metadata (including trace and cause).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->