### PR TITLE
名前付き引数の falsey 値を保持する

### DIFF
--- a/src/__tests__/ArgumentParser.test.ts
+++ b/src/__tests__/ArgumentParser.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import { run } from "@/testUtils";
+
+test("named arguments preserve falsey values before positional arguments", () => {
+  expect(run("distance(x1:0, 1, y1:0, x2:3, y2:4)")).toBe(5);
+  expect(run(`def(f(a,b),(a+":"+b)); f(a:false,2)`)).toBe("false:2");
+  expect(run(`def(f(a,b),(a+":"+b)); f(a:"",2)`)).toBe(":2");
+});

--- a/src/utils/argumentParser.ts
+++ b/src/utils/argumentParser.ts
@@ -31,7 +31,7 @@ const argumentParser: ArgumentParser = (
   let i = 0;
   for (const key of keys) {
     const value = nonKeyValues[i];
-    if (!result[key] && value) {
+    if (!Object.hasOwn(result, key) && value) {
       result[key] = compute ? execute(value, scopes, trace) : value;
       i++;
     }


### PR DESCRIPTION
## チケットへのリンク

* z/tasks.md の P2 タスク: 名前付き引数の falsey 値を未指定扱いしない

## やったこと

* 名前付き引数のスロットが埋まっているかを truthiness ではなくキー存在で判定するよう修正
* `0` / `false` / `""` の名前付き引数が後続の位置引数で上書きされない回帰テストを追加

## やらないこと

* `src/functions/distance.ts` の変更は不要だったため無し

## できるようになること（ユーザ目線）

* `distance(x1:0, 1, y1:0, x2:3, y2:4)` や `f(a:false,2)` で falsey な名前付き引数が保持される

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* `npm test -- --run src/__tests__/ArgumentParser.test.ts`
* `npm test -- --run`
* `npm run lint`
* `npm run check-types`
* pre-commit hook: lint / test / typecheck

## その他

* deep-review 観点の自己レビューと独立 subagent レビュー実施済み。独立レビューの指摘（回帰テストファイルの staging 漏れリスク）は staging 後に解消済み。

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing bug where falsey named arguments (`0`, `false`, `""`) were incorrectly overwritten by later positional arguments because slot-fill detection used a truthiness check (`!result[key]`) rather than a key-existence check.

- **`src/utils/argumentParser.ts`**: Replaces `!result[key]` with `!Object.hasOwn(result, key)` on the positional-fill loop, correctly preserving any explicitly named argument regardless of its value.
- **`src/__tests__/ArgumentParser.test.ts`**: Adds a new regression test covering all three falsey-value variants (`0`, `false`, `""`) to prevent regressions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, targeted one-line fix with direct regression tests.

The change is a single, well-understood predicate swap that correctly narrows overwrite conditions to only unfilled slots. All three falsey-value variants are covered by new regression tests, and the rest of the argument-parsing logic is unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/argumentParser.ts | Single-line fix: replaces truthiness check (!result[key]) with key-existence check (Object.hasOwn) so falsey named arguments (0, false, "") are not overwritten by subsequent positional arguments. |
| src/__tests__/ArgumentParser.test.ts | New regression test file covering all three falsey-value cases (0, false, "") for named arguments, using the existing run() test harness. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[inputs: Argument list] --> B{Has NIWANGO_Identifier?}
    B -->|Yes| C{key in keys?}
    C -->|Yes| D["result[key] = evaluated value"]
    D --> E[continue to next input]
    C -->|No| F[push to nonKeyValues]
    B -->|No| F
    F --> G[End of first loop]
    G --> H[Iterate over keys in order]
    H --> I{"Object.hasOwn(result, key)?"}
    I -->|Yes - named arg already set| J[skip - do NOT overwrite with positional]
    I -->|No - slot is empty| K{"nonKeyValues[i] exists?"}
    K -->|Yes| L["result[key] = nonKeyValues[i], i++"]
    K -->|No| M[leave key unset]
    J --> N[next key]
    L --> N
    M --> N
    N --> O[return result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[inputs: Argument list] --> B{Has NIWANGO_Identifier?}
    B -->|Yes| C{key in keys?}
    C -->|Yes| D["result[key] = evaluated value"]
    D --> E[continue to next input]
    C -->|No| F[push to nonKeyValues]
    B -->|No| F
    F --> G[End of first loop]
    G --> H[Iterate over keys in order]
    H --> I{"Object.hasOwn(result, key)?"}
    I -->|Yes - named arg already set| J[skip - do NOT overwrite with positional]
    I -->|No - slot is empty| K{"nonKeyValues[i] exists?"}
    K -->|Yes| L["result[key] = nonKeyValues[i], i++"]
    K -->|No| M[leave key unset]
    J --> N[next key]
    L --> N
    M --> N
    N --> O[return result]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/1fa7b1f18d722b5bee10b5d858ede9751381b74f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39362839)</sub>

<!-- /greptile_comment -->