### PR TITLE
Fix logical expression short-circuiting

### DIFF
--- a/src/__tests__/LogicalExpression.test.ts
+++ b/src/__tests__/LogicalExpression.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test, vi } from "vitest";
+import { run } from "@/testUtils";
+
+describe("LogicalExpression", () => {
+  test("does not evaluate right side when && short-circuits", () => {
+    expect(run("i=0;false&&(i=1);i")).toBe(0);
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(run("false&&notImplemented()")).toBe(false);
+      expect(consoleLog).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  test("does not evaluate right side when || short-circuits", () => {
+    expect(run("i=0;true||(i=1);i")).toBe(0);
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(run("true||notImplemented()")).toBe(true);
+      expect(consoleLog).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  test("evaluates right side when && does not short-circuit", () => {
+    expect(run("i=0;true&&(i=1);i")).toBe(1);
+  });
+
+  test("evaluates right side when || does not short-circuit", () => {
+    expect(run("i=0;false||(i=1);i")).toBe(1);
+  });
+});

--- a/src/processors/LogicalExpression.ts
+++ b/src/processors/LogicalExpression.ts
@@ -15,11 +15,10 @@ const processLogicalExpression = (
   trace: A_ANY[],
 ): unknown => {
   const left = execute(script.left, scopes, trace);
-  const right = execute(script.right, scopes, trace);
   if (script.operator === "&&") {
-    return left && right;
+    return left && execute(script.right, scopes, trace);
   } else if (script.operator === "||") {
-    return left || right;
+    return left || execute(script.right, scopes, trace);
   }
   throw new NotImplementedError(script, scopes);
 };


### PR DESCRIPTION
## Summary
- evaluate logical expression right operands lazily for && and ||
- add regression tests for skipped assignments and skipped unimplemented calls
- cover non-short-circuited assignment evaluation

## Validation
- ./node_modules/.bin/vitest src/__tests__/LogicalExpression.test.ts --run
- npm test -- --run
- npm run lint
- npm run check-types
- pre-commit hook: lint, test, typecheck

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a correctness bug where `&&` and `||` logical expressions were eagerly evaluating both operands before applying the short-circuit check. The right operand is now only passed to `execute` when the left-side value does not short-circuit.

- **`src/processors/LogicalExpression.ts`**: Removes the eager `execute(script.right, …)` call and inlines it inside each branch so it is only invoked when JS's own `&&`/`||` semantics actually need the value.
- **`src/__tests__/LogicalExpression.test.ts`**: Adds four regression tests covering skipped assignment, skipped unimplemented-function call (via `console.log` spy), and the non-short-circuited paths for both operators.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted correctness fix for short-circuit evaluation with solid test coverage.

The diff is two lines in a single well-understood function, replacing an eager evaluate-then-branch pattern with inline lazy evaluation inside each branch. The fix exactly matches JavaScript's own short-circuit semantics, and all four behavioral cases (skipped/non-skipped for each operator) are covered by the new tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/processors/LogicalExpression.ts | Fixes eager evaluation of the right operand — now lazily evaluated inside each branch, correctly implementing short-circuit semantics for && and ||. |
| src/__tests__/LogicalExpression.test.ts | New test file covering all four cases: skipped assignment and skipped unimplemented call for both && and ||, plus the non-short-circuited paths. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processLogicalExpression] --> B[execute left operand]
    B --> C{operator}
    C -->|and| D{left truthy?}
    D -->|No| E[return left - right skipped]
    D -->|Yes| F[execute right operand]
    F --> G[return result]
    C -->|or| H{left truthy?}
    H -->|Yes| I[return left - right skipped]
    H -->|No| J[execute right operand]
    J --> K[return result]
    C -->|other| L[throw NotImplementedError]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processLogicalExpression] --> B[execute left operand]
    B --> C{operator}
    C -->|and| D{left truthy?}
    D -->|No| E[return left - right skipped]
    D -->|Yes| F[execute right operand]
    F --> G[return result]
    C -->|or| H{left truthy?}
    H -->|Yes| I[return left - right skipped]
    H -->|No| J[execute right operand]
    J --> K[return result]
    C -->|other| L[throw NotImplementedError]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/3e0277e4f91aa7be79b0de770257a5620a083eb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39363997)</sub>

<!-- /greptile_comment -->