### PR TITLE
Fix parser syntax error boundary

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,0 +1,29 @@
+import { expect, test, vi } from "vitest";
+import { parseScript } from "@/parser/parse";
+import { SyntaxError as PeggySyntaxError, parse } from "@/parser/parser";
+
+test("parseScript surfaces syntax errors by default", () => {
+  const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+  try {
+    expect(() => parseScript("1@+2", "parser.test")).toThrow(PeggySyntaxError);
+    expect(info).not.toHaveBeenCalled();
+  } finally {
+    info.mockRestore();
+  }
+});
+
+test("parseScript character deletion recovery is opt-in", () => {
+  const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+  try {
+    expect(
+      parseScript("1@+2", "parser.test", { recoverSyntaxErrors: true }),
+    ).toEqual(parse("1+2", { grammarSource: "parser.test" }));
+    expect(() =>
+      parseScript("1+", "parser.test", { recoverSyntaxErrors: true }),
+    ).toThrow(PeggySyntaxError);
+  } finally {
+    info.mockRestore();
+  }
+});

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -20,6 +20,8 @@ test("parseScript character deletion recovery is opt-in", () => {
     expect(
       parseScript("1@+2", "parser.test", { recoverSyntaxErrors: true }),
     ).toEqual(parse("1+2", { grammarSource: "parser.test" }));
+    // Removing the trailing + leaves a bare numeric literal, which is still not
+    // a complete Niwango statement, so recovery should rethrow the first error.
     expect(() =>
       parseScript("1+", "parser.test", { recoverSyntaxErrors: true }),
     ).toThrow(PeggySyntaxError);

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { initCore, resetCore } from "@/init";
 import { parseScript } from "@/parser/parse";
 import { format } from "@/utils/format";
 
-import { NiwangoSyntaxError as PeggySyntaxError, parse } from "./parser/parser";
+import { SyntaxError as PeggySyntaxError, parse } from "./parser/parser";
 
 initCore();
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -3,6 +3,7 @@ import type { A_ANY } from "@/@types/ast";
 import { SyntaxError as PeggySyntaxError, parse } from "./parser";
 
 interface ParseScriptOptions {
+  /** Re-enable the legacy Peggy syntax-error character deletion loop. */
   recoverSyntaxErrors?: boolean;
 }
 

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,11 +1,22 @@
 import type { A_ANY } from "@/@types/ast";
 
-import { NiwangoSyntaxError as PeggySyntaxError, parse } from "./parser";
+import { SyntaxError as PeggySyntaxError, parse } from "./parser";
 
-const parseScript = (content: string, name: string): A_ANY => {
+interface ParseScriptOptions {
+  recoverSyntaxErrors?: boolean;
+}
+
+const parseScript = (
+  content: string,
+  name: string,
+  options: ParseScriptOptions = {},
+): A_ANY => {
   let script = content;
   if (script.startsWith("/")) {
     script = script.slice(1);
+  }
+  if (!options.recoverSyntaxErrors) {
+    return parse(script, { grammarSource: name });
   }
   let firstError: unknown;
   for (let i = 0; i < 1000; i++) {
@@ -28,3 +39,4 @@ const parseScript = (content: string, name: string): A_ANY => {
 };
 
 export { parseScript };
+export type { ParseScriptOptions };

--- a/src/parser/parser.d.ts
+++ b/src/parser/parser.d.ts
@@ -1,5 +1,11 @@
 import { A_ANY } from "@/@types/ast";
 
+type ParserLocation = {
+  start: { offset: number; line: number; column: number };
+  end: { offset: number; line: number; column: number };
+  source: string;
+};
+
 /**
  * ニワン語をASTに変換するパーサー
  * @param script
@@ -15,20 +21,19 @@ export function parse(
  * パースエラーが発生した際に投げられるエラー?
  * 多分型はあってるはず
  */
-export class NiwangoSyntaxError extends Error {
+declare class PeggySyntaxError extends Error {
   constructor(
     message: string,
-    expected: string,
-    found: string,
-    location: string,
+    expected: unknown,
+    found: string | null,
+    location: ParserLocation,
   );
-  expected: string;
-  found: string;
-  location: {
-    start: { offset: number; line: number; column: number };
-    end: { offset: number; line: number; column: number };
-    source: string;
-  };
+  expected: unknown;
+  found: string | null;
+  location: ParserLocation;
   name: "SyntaxError";
   format: (sources: { source: string; text: string }[]) => string;
+  static buildMessage: (expected: unknown, found: string | null) => string;
 }
+
+export { PeggySyntaxError as SyntaxError };


### PR DESCRIPTION
## Summary
- make parseScript syntax-error deletion recovery opt-in via recoverSyntaxErrors
- align parser declarations/imports with the generated runtime SyntaxError export
- add focused parser boundary regression tests

## Breaking boundary
- This intentionally changes default parseScript behavior: callers that still want legacy character-deletion recovery must pass { recoverSyntaxErrors: true }. Downstream niwango.js callers should opt in explicitly if they rely on the old auto-repair behavior.

## Validation
- npm test -- --run src/__tests__/parser.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm_config_verify_deps_before_run=false pnpm test --run
- pre-commit hook passed on both commits: lint, test, typecheck

## Review
- deep-review self pass: no findings
- independent subagent review: no findings
- gh-review-hook finding response: documented intentional downstream breaking boundary; added comments for opt-in recovery and irrecoverable recovery test

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `parseScript`'s syntax-error character-deletion recovery opt-in via a new `{ recoverSyntaxErrors: true }` option (breaking the previous always-on default), aligns the `parser.d.ts` declaration with the actual Peggy-generated `SyntaxError` export (replacing the stale `NiwangoSyntaxError` alias), and adds a focused regression test suite for both the default-throw and opt-in-recovery paths.

- **Behavioral change**: `parseScript` now calls `parse()` directly and surfaces errors immediately unless `recoverSyntaxErrors: true` is passed; the legacy deletion loop is still present and exercised by the new test.
- **Type-declaration cleanup**: `parser.d.ts` drops `NiwangoSyntaxError`, corrects constructor parameter types (`expected: unknown`, `found: string | null`), adds the `ParserLocation` named type, and surfaces `static buildMessage` — all matching the actual Peggy runtime API.
- **Downstream impact (acknowledged)**: `niwango.js` calls `Core.parseScript` without a third argument in both `main.ts` (try/caught) and `testUtils.ts` (no try/catch); the PR description explicitly documents this as an intentional breaking boundary that callers must opt into.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the behavioral change is deliberate and well-documented, and all affected call-sites in the related repos have been accounted for.

The change is narrow and self-contained: the opt-in flag is correctly gated, the default path is a straight parse() call with no new error-swallowing, the declaration file now faithfully mirrors the Peggy runtime, and the new tests exercise both code paths. The downstream impact on niwango.js is explicitly called out in the PR as an intentional breaking boundary rather than an oversight.

No files require special attention beyond the acknowledged downstream impact on niwango.js.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/parser/parse.ts | Recovery loop made opt-in via `recoverSyntaxErrors` option; default path now calls `parse()` directly and lets errors propagate — intentional breaking change documented in PR description. |
| src/parser/parser.d.ts | Declaration updated to match the real Peggy runtime: renamed to `PeggySyntaxError`, exported as `SyntaxError`, corrected parameter types, extracted `ParserLocation`, added `static buildMessage`. |
| src/main.ts | Import alias updated from `NiwangoSyntaxError` to `SyntaxError` to match the new declaration; no behavioral change at the public API surface. |
| src/__tests__/parser.test.ts | New test file covering the default-throw path and the opt-in recovery path; irrecoverability case now has an inline comment explaining why `"1"` is not a valid Niwango statement. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parseScript(content, name, options?)"] --> B{startsWith '/'}
    B -- yes --> C[strip leading '/']
    B -- no --> D{recoverSyntaxErrors?}
    C --> D
    D -- false / default --> E["parse(script, {grammarSource: name})"]
    E -- success --> F[return AST]
    E -- PeggySyntaxError --> G[throw immediately]
    D -- true --> H["Recovery loop (up to 1000 iterations)"]
    H --> I["parse(script, {grammarSource: name})"]
    I -- success --> F
    I -- PeggySyntaxError --> J[console.info error]
    J --> K[remove char at error offset]
    K --> L{script unchanged?}
    L -- yes --> M[throw firstError]
    L -- no --> I
    I -- non-SyntaxError --> N[throw immediately]
    H -- loop exhausted --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["parseScript(content, name, options?)"] --> B{startsWith '/'}
    B -- yes --> C[strip leading '/']
    B -- no --> D{recoverSyntaxErrors?}
    C --> D
    D -- false / default --> E["parse(script, {grammarSource: name})"]
    E -- success --> F[return AST]
    E -- PeggySyntaxError --> G[throw immediately]
    D -- true --> H["Recovery loop (up to 1000 iterations)"]
    H --> I["parse(script, {grammarSource: name})"]
    I -- success --> F
    I -- PeggySyntaxError --> J[console.info error]
    J --> K[remove char at error offset]
    K --> L{script unchanged?}
    L -- yes --> M[throw firstError]
    L -- no --> I
    I -- non-SyntaxError --> N[throw immediately]
    H -- loop exhausted --> M
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/994456c51a2814953da2bcf986939edf06d5b109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39414351)</sub>

<!-- /greptile_comment -->