### PR TITLE
Harden package build and pnpm install config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pegjs": "peggy --cache -o ./src/parser/parser.js --format umd --export-var parser ./src/grammar/niwango.pegjs",
     "watch": "rollup -c rollup.config.mjs -w",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run build",
     "check-types": "npx tsc --noEmit --jsx react",
     "eslint": "biome lint src",
@@ -20,7 +21,7 @@
     "format:fix": "biome format --write src",
     "lint": "biome check src",
     "lint:fix": "biome check --write --unsafe src",
-    "prepare": "lefthook install",
+    "prepare": "node -e \"const{existsSync}=require('fs');const{spawnSync}=require('child_process');if(process.env.CI||!existsSync('.git')||(!existsSync('node_modules/.bin/lefthook')&&!existsSync('node_modules/.bin/lefthook.cmd')))process.exit(0);const cmd=process.platform==='win32'?'lefthook.cmd':'lefthook';process.exit(spawnSync(cmd,['install'],{stdio:'inherit',shell:process.platform==='win32'}).status??1)\"",
     "test": "vitest"
   },
   "files": [
@@ -52,11 +53,5 @@
     "typedoc-plugin-missing-exports": "^4.1.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "watch": "rollup -c rollup.config.mjs -w",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
     "prepack": "npm run build",
-    "prepublishOnly": "npm run build",
     "check-types": "npx tsc --noEmit --jsx react",
     "eslint": "biome lint src",
     "eslint:fix": "biome lint --write src",
@@ -21,7 +20,7 @@
     "format:fix": "biome format --write src",
     "lint": "biome check src",
     "lint:fix": "biome check --write --unsafe src",
-    "prepare": "node -e \"const{existsSync}=require('fs');const{spawnSync}=require('child_process');if(process.env.CI||!existsSync('.git')||(!existsSync('node_modules/.bin/lefthook')&&!existsSync('node_modules/.bin/lefthook.cmd')))process.exit(0);const cmd=process.platform==='win32'?'lefthook.cmd':'lefthook';process.exit(spawnSync(cmd,['install'],{stdio:'inherit',shell:process.platform==='win32'}).status??1)\"",
+    "prepare": "node -e \"process.exit(process.env.CI?0:1)\" || lefthook install || node -e \"process.exit(0)\"",
     "test": "vitest"
   },
   "files": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  lefthook: true


### PR DESCRIPTION
## Summary
- build dist during package creation with prepack
- guard prepare so lefthook install does not break CI, package installs, or installs without the lefthook binary
- move pnpm build-script approvals into pnpm-workspace.yaml allowBuilds for pnpm 11, fixing the shared ignored-builds install blocker seen on PR #20 and PR #21

## Validation
- CI=true pnpm install --frozen-lockfile
- npm run build
- npm run lint
- npm run check-types
- CI=true npm pack --dry-run --json (confirmed dist/niwango-core.js and dist/niwango-core.d.ts)
- packed tarball smoke: CommonJS require() and TypeScript import

## Review
- deep-review self pass: no actionable findings after final diff
- independent reviewer: initial stale onlyBuiltDependencies finding fixed; second pass no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the build and install configuration by switching `prepublishOnly` to `prepack` (ensuring `dist/` is built during `npm pack`), guarding the `prepare` script against CI environments and missing lefthook binaries, and migrating pnpm's build-script allowlist from `package.json`'s `pnpm.onlyBuiltDependencies` to `pnpm-workspace.yaml`'s `allowBuilds` (the correct location for pnpm 10.1+).

- **`prepack`**: Replacing `prepublishOnly` with `prepack` ensures the dist is built before both `npm pack` and `npm publish`, fixing the missing-dist issue validated in the PR smoke test.
- **`prepare` guard**: The three-part `||` chain correctly short-circuits on `CI`, falls through to `lefthook install` for local dev, and swallows failures (missing binary, absent `.git`) without breaking installs.
- **`pnpm-workspace.yaml` `allowBuilds`**: The `allowBuilds: { esbuild: true, lefthook: true }` map format matches the official pnpm 10.1+ spec; the old `pnpm.onlyBuiltDependencies` in `package.json` is correctly removed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to build lifecycle hooks and pnpm install configuration with no impact on runtime code.

Both changed files deal exclusively with packaging and install-time behavior. The `prepack` hook correctly triggers the build before tarball creation, the `prepare` guard logic handles all three install scenarios (CI, local dev, dependency consumer), and the `allowBuilds` migration in `pnpm-workspace.yaml` matches the pnpm 10.1+ spec. No runtime code paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Switches `prepublishOnly` to `prepack` and hardens the `prepare` script with a CI/binary-existence guard; removes the now-superseded `pnpm.onlyBuiltDependencies` block. Logic is sound across all install scenarios. |
| pnpm-workspace.yaml | New file introducing `allowBuilds` for esbuild and lefthook; format matches the pnpm 10.1+ `pnpm-workspace.yaml` spec from the official `approve-builds` docs. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant npm
    participant pnpm
    participant lefthook

    Note over Dev,lefthook: npm install (local dev)
    Dev->>npm: npm install
    npm->>npm: install devDependencies
    npm->>lefthook: prepare: lefthook install
    lefthook-->>npm: hooks installed

    Note over Dev,lefthook: CI install (CI=true)
    Dev->>npm: "CI=true npm install"
    npm->>npm: node -e process.exit(0) [CI set - skip]
    npm-->>Dev: prepare exits 0, lefthook skipped

    Note over Dev,lefthook: npm pack / npm publish
    Dev->>npm: npm pack
    npm->>npm: prepack: npm run build
    npm->>npm: build dist/niwango-core.js + .d.ts
    npm-->>Dev: tarball with dist/

    Note over Dev,pnpm: pnpm install (pnpm 10.1+)
    Dev->>pnpm: pnpm install
    pnpm->>pnpm: read allowBuilds from pnpm-workspace.yaml
    pnpm->>pnpm: allow esbuild + lefthook postinstall scripts
    pnpm-->>Dev: install complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant npm
    participant pnpm
    participant lefthook

    Note over Dev,lefthook: npm install (local dev)
    Dev->>npm: npm install
    npm->>npm: install devDependencies
    npm->>lefthook: prepare: lefthook install
    lefthook-->>npm: hooks installed

    Note over Dev,lefthook: CI install (CI=true)
    Dev->>npm: "CI=true npm install"
    npm->>npm: node -e process.exit(0) [CI set - skip]
    npm-->>Dev: prepare exits 0, lefthook skipped

    Note over Dev,lefthook: npm pack / npm publish
    Dev->>npm: npm pack
    npm->>npm: prepack: npm run build
    npm->>npm: build dist/niwango-core.js + .d.ts
    npm-->>Dev: tarball with dist/

    Note over Dev,pnpm: pnpm install (pnpm 10.1+)
    Dev->>pnpm: pnpm install
    pnpm->>pnpm: read allowBuilds from pnpm-workspace.yaml
    pnpm->>pnpm: allow esbuild + lefthook postinstall scripts
    pnpm-->>Dev: install complete
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address package lifecycle review feedbac..."](https://github.com/xpadev-net/niwango-core.js/commit/00ba9003d9c7bf3d080a6e65a46a38eceef3eafe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39415711)</sub>

<!-- /greptile_comment -->