### PR TITLE
Fix dynamic call argument forwarding

### DIFF
--- a/src/__tests__/Value.test.ts
+++ b/src/__tests__/Value.test.ts
@@ -29,4 +29,13 @@ describe("Value.prototype", () => {
     expect(run(`10.minus`)).toBe(-10);
     expect(run(`-5.minus`)).toBe(5);
   });
+  test("dynamic call", () => {
+    expect(run(`def(f(a,b),a+b); 0.call("f",1,2)`)).toBe(3);
+    expect(run(`def(f(a,b),(a+":"+b)); 0.call("f",b:"B",a:"A")`)).toBe("A:B");
+    expect(run(`def(f(),"ok"); 0.call("f")`)).toBe("ok");
+    expect(run(`def(f(a,b),a+b); 0.sendMessage("f",1,2)`)).toBe(3);
+    expect(run(`def(f(a,b),(a+":"+b)); 0.sendMessage("f",b:"B",a:"A")`)).toBe(
+      "A:B",
+    );
+  });
 });

--- a/src/prototype/Value/call.ts
+++ b/src/prototype/Value/call.ts
@@ -26,7 +26,7 @@ const processCall: PrototypeValueFunction = (
       type: "Raw",
       value: functionName,
     },
-    arguments: script.arguments[1] ? [script.arguments[1]] : [],
+    arguments: script.arguments.slice(1),
   };
   return execute(newScript, scopes, trace);
 };


### PR DESCRIPTION
## Summary
- Forward all arguments after the dynamic function-name argument in Value.call/processCall.
- Add regression coverage for multi-argument, named-argument, no-argument target, and sendMessage dynamic calls.

## Validation
- npm test -- --run src/__tests__/Value.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run

## Review
- Deep-review self-pass: no actionable findings.
- Independent subagent review: no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug in `processCall` where only the first extra argument was forwarded when calling a dynamically-named function via `Value.call`/`sendMessage`; adds regression tests for multi-arg, named-arg, no-arg, and `sendMessage` variants.

- The old code `script.arguments[1] ? [script.arguments[1]] : []` silently dropped every argument beyond the second, so any call with two or more arguments would produce wrong results. The fix replaces this with `script.arguments.slice(1)`, which correctly forwards all remaining arguments.
- New tests in `Value.test.ts` directly cover the previously broken paths and confirm both positional and named-argument forwarding work correctly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted correction to argument forwarding with direct test coverage for every affected case.

The single-line change from hand-rolled single-element wrapping to slice(1) is straightforward and the new tests directly exercise the previously broken multi-argument paths, named-argument paths, and the no-argument edge case. No other callers or related consumers in the linked repos were found to depend on the old (broken) behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/prototype/Value/call.ts | One-line bug fix: replaces single-argument forwarding with slice(1) to correctly pass all trailing arguments to the dynamically-resolved callee. |
| src/__tests__/Value.test.ts | Adds five regression cases covering multi-arg, named-arg, no-arg, and sendMessage dynamic calls; good coverage for the fixed path. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Script (0.call("f",1,2))
    participant processCall
    participant execute

    Caller->>processCall: "script.arguments = ["f", 1, 2]"
    processCall->>execute: "evaluate arguments[0] → functionName = "f""
    Note over processCall: Build newScript<br/>callee: Raw("f")<br/>arguments: slice(1) → [1, 2]
    processCall->>execute: "execute(newScript{f(1,2)}, scopes, trace)"
    execute-->>Caller: result (3)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Script (0.call("f",1,2))
    participant processCall
    participant execute

    Caller->>processCall: "script.arguments = ["f", 1, 2]"
    processCall->>execute: "evaluate arguments[0] → functionName = "f""
    Note over processCall: Build newScript<br/>callee: Raw("f")<br/>arguments: slice(1) → [1, 2]
    processCall->>execute: "execute(newScript{f(1,2)}, scopes, trace)"
    execute-->>Caller: result (3)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/6ddceb2c61938af0df04a8d3ce852f35fc4faa66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39429502)</sub>

<!-- /greptile_comment -->