### PR TITLE
Enforce shared runtime resource limits

### DIFF
--- a/src/@types/config.d.ts
+++ b/src/@types/config.d.ts
@@ -1,3 +1,11 @@
+export type ResourceLimits = {
+  loopIterations: number;
+  timesIterations: number;
+  stringRepeatCount: number;
+  stringRepeatLength: number;
+  recursionDepth: number;
+};
+
 export type baseConfig = {
   stageWidth: {
     default: number;
@@ -6,5 +14,6 @@ export type baseConfig = {
   stageHeight: number;
   canvasWidth: number;
   canvasHeight: number;
+  resourceLimits: ResourceLimits;
   recursionLimit?: number;
 };

--- a/src/__tests__/ResourceLimits.test.ts
+++ b/src/__tests__/ResourceLimits.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { config, initConfig } from "@/config";
+import { ResourceLimitError, TooMuchRecursionError } from "@/errors";
+import { run } from "@/testUtils";
+
+describe("resource limits", () => {
+  afterEach(() => {
+    initConfig();
+  });
+
+  test("function while_kari allows the configured iteration limit", () => {
+    config.resourceLimits.loopIterations = 3;
+
+    expect(run("i=0;while_kari(i<3,i++);i")).toBe(3);
+  });
+
+  test("function while_kari throws just above the configured iteration limit", () => {
+    config.resourceLimits.loopIterations = 3;
+
+    expect(() => run("i=0;while_kari(i<4,i++);i")).toThrow(ResourceLimitError);
+  });
+
+  test("prototype while_kari allows the configured iteration limit", () => {
+    config.resourceLimits.loopIterations = 3;
+
+    expect(run("i=0;true.while_kari(i<3,i++);i")).toBe(3);
+  });
+
+  test("prototype while_kari throws just above the configured iteration limit", () => {
+    config.resourceLimits.loopIterations = 3;
+
+    expect(() => run("i=0;true.while_kari(i<4,i++);i")).toThrow(
+      ResourceLimitError,
+    );
+  });
+
+  test("Number.times allows the configured iteration limit", () => {
+    config.resourceLimits.timesIterations = 3;
+
+    expect(run("i=0;3.times(i++);i")).toBe(3);
+  });
+
+  test("Number.times throws just above the configured iteration limit", () => {
+    config.resourceLimits.timesIterations = 3;
+
+    expect(() => run("i=0;4.times(i++);i")).toThrow(ResourceLimitError);
+  });
+
+  test("string multiplication allows the configured repeat boundary", () => {
+    config.resourceLimits.stringRepeatCount = 3;
+    config.resourceLimits.stringRepeatLength = 3;
+
+    expect(run("'x' * 3")).toBe("xxx");
+  });
+
+  test("string multiplication throws just above the configured repeat count", () => {
+    config.resourceLimits.stringRepeatCount = 3;
+
+    expect(() => run("'x' * 4")).toThrow(ResourceLimitError);
+  });
+
+  test("string multiplication throws just above the configured repeat size", () => {
+    config.resourceLimits.stringRepeatLength = 3;
+
+    expect(() => run("'xx'.multiply(2)")).toThrow(ResourceLimitError);
+  });
+
+  test("recursion limit throws even when legacy catch mode is enabled", () => {
+    config.resourceLimits.recursionDepth = 20;
+
+    expect(() => run("def(f(), f()); f()", { catch: true })).toThrow(
+      TooMuchRecursionError,
+    );
+  });
+});

--- a/src/__tests__/ResourceLimits.test.ts
+++ b/src/__tests__/ResourceLimits.test.ts
@@ -72,4 +72,10 @@ describe("resource limits", () => {
       TooMuchRecursionError,
     );
   });
+
+  test("legacy recursionLimit zero keeps recursion checking disabled", () => {
+    config.recursionLimit = 0;
+
+    expect(run("def(f(), 1); f()")).toBe(1);
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ const initConfig = () => {
 
 const getResourceLimit = (limitName: ResourceLimitKey) => {
   if (limitName === "recursionDepth" && config.recursionLimit !== undefined) {
-    return config.recursionLimit;
+    return config.recursionLimit || Number.POSITIVE_INFINITY;
   }
   return config.resourceLimits[limitName];
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,18 @@
+import type { A_ANY, T_scope } from "@/@types/ast";
 import type { baseConfig } from "@/@types/config";
+import { ResourceLimitError } from "@/errors/ResourceLimitError";
 
 let config: baseConfig;
+const DEFAULT_RESOURCE_LIMITS: baseConfig["resourceLimits"] = {
+  loopIterations: 10000,
+  timesIterations: 10000,
+  stringRepeatCount: 10000,
+  stringRepeatLength: 1000000,
+  recursionDepth: 1000,
+};
+
+type ResourceLimitKey = keyof baseConfig["resourceLimits"];
+
 const initConfig = () => {
   config = {
     stageWidth: {
@@ -10,7 +22,34 @@ const initConfig = () => {
     stageHeight: 384,
     canvasWidth: 672,
     canvasHeight: 384,
+    resourceLimits: { ...DEFAULT_RESOURCE_LIMITS },
   };
 };
 
-export { config, initConfig };
+const getResourceLimit = (limitName: ResourceLimitKey) => {
+  if (limitName === "recursionDepth" && config.recursionLimit !== undefined) {
+    return config.recursionLimit;
+  }
+  return config.resourceLimits[limitName];
+};
+
+const assertResourceLimit = (
+  limitName: ResourceLimitKey,
+  actual: number,
+  ast?: A_ANY,
+  scopes?: T_scope[],
+  displayName: string = limitName,
+) => {
+  const limit = getResourceLimit(limitName);
+  if (actual > limit) {
+    throw new ResourceLimitError(displayName, limit, actual, ast, scopes);
+  }
+};
+
+export {
+  assertResourceLimit,
+  config,
+  DEFAULT_RESOURCE_LIMITS,
+  getResourceLimit,
+  initConfig,
+};

--- a/src/errors/ResourceLimitError.ts
+++ b/src/errors/ResourceLimitError.ts
@@ -1,0 +1,37 @@
+import type { A_ANY, T_scope } from "@/@types/ast";
+
+class ResourceLimitError extends Error {
+  ASTName?: string;
+  ast?: A_ANY;
+  scopes?: T_scope[];
+  limitName: string;
+  limit: number;
+  actual: number;
+
+  constructor(
+    limitName: string,
+    limit: number,
+    actual: number,
+    ast?: A_ANY,
+    scopes?: T_scope[],
+    options: { [key: string]: unknown } = {},
+  ) {
+    super(
+      `${limitName} resource limit exceeded: ${actual} > ${limit}`,
+      options,
+    );
+    this.limitName = limitName;
+    this.limit = limit;
+    this.actual = actual;
+    if (ast) {
+      this.ASTName = ast.type;
+      this.ast = ast;
+    }
+    if (scopes) {
+      this.scopes = scopes;
+    }
+  }
+}
+
+ResourceLimitError.prototype.name = "ResourceLimitError";
+export { ResourceLimitError };

--- a/src/errors/TooMuchRecursionError.ts
+++ b/src/errors/TooMuchRecursionError.ts
@@ -1,21 +1,18 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
+import { ResourceLimitError } from "@/errors/ResourceLimitError";
 
 /**
  * 未実装の関数や機能を呼び出したときに発生するエラー
  */
-class TooMuchRecursionError extends Error {
-  ASTName: string;
-  ast: A_ANY;
-  scopes: T_scope[];
+class TooMuchRecursionError extends ResourceLimitError {
   constructor(
     ast: A_ANY,
     scopes: T_scope[],
+    limit = 0,
+    actual = 0,
     options: { [key: string]: unknown } = {},
   ) {
-    super("TooMuchRecursionError", options);
-    this.ASTName = ast.type;
-    this.ast = ast;
-    this.scopes = scopes;
+    super("recursion depth", limit, actual, ast, scopes, options);
   }
 }
 TooMuchRecursionError.prototype.name = "TooMuchRecursionError";

--- a/src/errors/TooMuchRecursionError.ts
+++ b/src/errors/TooMuchRecursionError.ts
@@ -2,14 +2,14 @@ import type { A_ANY, T_scope } from "@/@types/ast";
 import { ResourceLimitError } from "@/errors/ResourceLimitError";
 
 /**
- * 未実装の関数や機能を呼び出したときに発生するエラー
+ * 再帰呼び出しの深さが制限を超えたときに発生するエラー
  */
 class TooMuchRecursionError extends ResourceLimitError {
   constructor(
     ast: A_ANY,
     scopes: T_scope[],
-    limit = 0,
-    actual = 0,
+    limit: number,
+    actual: number,
     options: { [key: string]: unknown } = {},
   ) {
     super("recursion depth", limit, actual, ast, scopes, options);

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,4 @@
 export * from "./InvalidTypeError";
 export * from "./NotImplementedError";
+export * from "./ResourceLimitError";
+export * from "./TooMuchRecursionError";

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,8 +1,9 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 import type { Execute } from "@/@types/execute";
-import { config } from "@/config";
+import { getResourceLimit } from "@/config";
 import { resultHook, setExecute } from "@/context";
 import { NotImplementedError } from "@/errors/NotImplementedError";
+import { ResourceLimitError } from "@/errors/ResourceLimitError";
 import { TooMuchRecursionError } from "@/errors/TooMuchRecursionError";
 import { processors } from "@/processors";
 import typeGuard from "@/typeGuard";
@@ -21,8 +22,14 @@ const execute: Execute = (
   options: Partial<{ catch: boolean }> = {},
 ): unknown => {
   if (!script || !typeGuard.AST(script)) return;
-  if (config.recursionLimit && trace.length > config.recursionLimit) {
-    throw new TooMuchRecursionError(script, scopes);
+  const recursionLimit = getResourceLimit("recursionDepth");
+  if (trace.length > recursionLimit) {
+    throw new TooMuchRecursionError(
+      script,
+      scopes,
+      recursionLimit,
+      trace.length,
+    );
   }
   let result: unknown;
   trace = [...trace, script];
@@ -31,6 +38,7 @@ const execute: Execute = (
     if (!processor) throw new NotImplementedError(script, scopes);
     result = processor(script, scopes, trace);
   } catch (e) {
+    if (e instanceof ResourceLimitError) throw e;
     if (!options.catch) throw e;
     const err = e as Record<string, unknown>;
     console.log(e, err.ast, err.scopes);

--- a/src/functions/while_kari.ts
+++ b/src/functions/while_kari.ts
@@ -1,5 +1,6 @@
 import type { A_ANY, A_CallExpression, T_scope } from "@/@types/ast";
 import type { IrFunction } from "@/@types/functions";
+import { assertResourceLimit } from "@/config";
 import { execute } from "@/context";
 
 /**
@@ -20,8 +21,16 @@ const processWhileKari: IrFunction = (
     return;
   }
   let loopCount = 0;
-  while (execute(script.arguments[0], scopes, trace) && loopCount++ <= 10000) {
+  while (execute(script.arguments[0], scopes, trace)) {
+    assertResourceLimit(
+      "loopIterations",
+      loopCount + 1,
+      script,
+      scopes,
+      "while_kari iterations",
+    );
     execute(script.arguments[1], scopes, trace);
+    loopCount++;
   }
 };
 

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,3 +1,4 @@
+import { assertResourceLimit } from "@/config";
 import { format } from "@/utils/format";
 
 /**
@@ -8,9 +9,31 @@ import { format } from "@/utils/format";
  */
 const Multiplication = (left: unknown, right: unknown) => {
   if (typeof left === "string") {
-    return left.repeat(format(right, "number"));
+    const repeatCount = format(right, "number");
+    assertStringRepeatResourceLimit(left, repeatCount);
+    return left.repeat(repeatCount);
   }
   return format(left, "number") * format(right, "number");
+};
+
+const assertStringRepeatResourceLimit = (value: string, repeat: number) => {
+  const repeatCount = Math.trunc(repeat);
+  if (Number.isNaN(repeatCount) || repeatCount <= 0) return;
+
+  assertResourceLimit(
+    "stringRepeatCount",
+    repeatCount,
+    undefined,
+    undefined,
+    "string repeat count",
+  );
+  assertResourceLimit(
+    "stringRepeatLength",
+    value.length * repeatCount,
+    undefined,
+    undefined,
+    "string repeat length",
+  );
 };
 
 /**

--- a/src/prototype/Number/times.ts
+++ b/src/prototype/Number/times.ts
@@ -1,4 +1,5 @@
 import type { A_ANY, Argument } from "@/@types/ast";
+import { assertResourceLimit } from "@/config";
 import { execute } from "@/context";
 import type { PrototypeNumberFunction } from "@/prototype/Number/index";
 import { format } from "@/utils/format";
@@ -10,8 +11,17 @@ const processTimes: PrototypeNumberFunction = (
   trace: A_ANY[],
 ) => {
   const body = script.arguments[0] as Argument<A_ANY>;
+  const count = format(object, "number");
+  const iterations = Number.isNaN(count) || count <= 0 ? 0 : Math.ceil(count);
+  assertResourceLimit(
+    "timesIterations",
+    iterations,
+    script,
+    scopes,
+    "Number.times iterations",
+  );
   let lastResult: unknown;
-  for (let i = 0; i < format(object, "number"); i++) {
+  for (let i = 0; i < count; i++) {
     if (body.type === "LambdaExpression") {
       lastResult = execute(body.body, [{ "@0": i }, ...scopes], trace);
       continue;

--- a/src/prototype/Value/while_kari.ts
+++ b/src/prototype/Value/while_kari.ts
@@ -1,4 +1,5 @@
 import type { A_ANY } from "@/@types";
+import { assertResourceLimit } from "@/config";
 import { execute } from "@/context";
 import type { PrototypeValueFunction } from "@/prototype/Value/index";
 
@@ -9,9 +10,18 @@ const processWhileKari: PrototypeValueFunction = (
   trace: A_ANY[],
 ) => {
   let result: unknown;
+  let loopCount = 0;
   while (execute(script.arguments[0], scopes, trace) as boolean) {
+    assertResourceLimit(
+      "loopIterations",
+      loopCount + 1,
+      script,
+      scopes,
+      "while_kari iterations",
+    );
     // eslint-disable-next-line prefer-const
     result = execute(script.arguments[1], scopes, trace);
+    loopCount++;
   }
   return result;
 };


### PR DESCRIPTION
## Summary
- centralize runtime resource limit defaults in config
- enforce limits for while_kari, Number.times, string repetition, and recursion depth
- add ResourceLimitError and focused boundary tests

## Validation
- pnpm vitest run src/__tests__/ResourceLimits.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- self-review with deep-review checklist: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes runtime resource-limit defaults into a single `config.resourceLimits` object and enforces those limits across `while_kari` (both function and prototype forms), `Number.times`, and string repetition, while also propagating `ResourceLimitError` correctly through the executor's catch-mode guard.

- **New `ResourceLimitError` hierarchy**: `TooMuchRecursionError` now extends `ResourceLimitError`, and the executor re-throws any `ResourceLimitError` even when `catch: true` is set, so recursion and loop overruns can't be silently swallowed.
- **Backward-compat shim**: `getResourceLimit(\"recursionDepth\")` honours the legacy `config.recursionLimit` field; `0` is treated as \"no limit\" (`POSITIVE_INFINITY`) to match old behaviour, verified by a dedicated test.
- **Boundary tests**: `ResourceLimits.test.ts` exercises the exact limit, one-over-limit, and legacy-zero cases for every guarded operation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; logic is correct, legacy compatibility is preserved, and all boundary conditions are covered by focused tests.

All four guarded operations enforce limits correctly, the legacy recursionLimit=0 escape hatch behaves identically to before, and ResourceLimitError now propagates reliably through catch mode. The only note is that DEFAULT_RESOURCE_LIMITS is exported as a mutable object, which is a hardening concern rather than a current defect.

src/config.ts — the exported DEFAULT_RESOURCE_LIMITS object is mutable; consider freezing it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/config.ts | Introduces DEFAULT_RESOURCE_LIMITS, assertResourceLimit, and getResourceLimit; the legacy recursionLimit=0 escape hatch is correctly preserved, but DEFAULT_RESOURCE_LIMITS is exported as a mutable object |
| src/executor.ts | ResourceLimitError (and its TooMuchRecursionError subclass) is now re-thrown from the catch block, ensuring limit violations propagate even when catch mode is enabled |
| src/errors/ResourceLimitError.ts | New error class with correct message formatting and optional AST/scope diagnostic fields |
| src/errors/TooMuchRecursionError.ts | Refactored to extend ResourceLimitError; JSDoc updated; constructor now requires limit and actual for meaningful error messages |
| src/functions/while_kari.ts | Resource limit check correctly placed inside the loop after condition evaluation, counting body executions; allows exactly loopIterations iterations before throwing |
| src/prototype/Number/times.ts | Upfront limit check using Math.ceil correctly matches the actual loop iteration count for fractional counts; NaN and non-positive counts are safely short-circuited to 0 |
| src/operators.ts | String repeat limits correctly guard both count and resulting length; Math.trunc matches String.prototype.repeat's internal truncation for positive values |
| src/__tests__/ResourceLimits.test.ts | Tests cover boundary cases for all four limit types plus the legacy recursionLimit=0 escape hatch; afterEach resets config fully via initConfig() |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[execute called] --> B{trace.length > recursionDepth limit?}
    B -- yes --> C[throw TooMuchRecursionError]
    B -- no --> D[processor script]
    D --> E{operator / function}
    E -- while_kari --> F[evaluate condition]
    F -- true --> G{loopCount+1 > loopIterations?}
    G -- yes --> H[throw ResourceLimitError]
    G -- no --> I[execute body loopCount++]
    I --> F
    F -- false --> Z[done]
    E -- Number.times --> J{Math.ceil count > timesIterations?}
    J -- yes --> H
    J -- no --> K[for loop body]
    K --> Z
    E -- string x n --> L{repeatCount > stringRepeatCount OR length x n > stringRepeatLength?}
    L -- yes --> H
    L -- no --> M[String.repeat]
    M --> Z
    D --> N{catch block}
    N -- instanceof ResourceLimitError --> O[re-throw]
    N -- options.catch false --> O
    N -- catch mode on, not ResourceLimitError --> P[log and swallow]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[execute called] --> B{trace.length > recursionDepth limit?}
    B -- yes --> C[throw TooMuchRecursionError]
    B -- no --> D[processor script]
    D --> E{operator / function}
    E -- while_kari --> F[evaluate condition]
    F -- true --> G{loopCount+1 > loopIterations?}
    G -- yes --> H[throw ResourceLimitError]
    G -- no --> I[execute body loopCount++]
    I --> F
    F -- false --> Z[done]
    E -- Number.times --> J{Math.ceil count > timesIterations?}
    J -- yes --> H
    J -- no --> K[for loop body]
    K --> Z
    E -- string x n --> L{repeatCount > stringRepeatCount OR length x n > stringRepeatLength?}
    L -- yes --> H
    L -- no --> M[String.repeat]
    M --> Z
    D --> N{catch block}
    N -- instanceof ResourceLimitError --> O[re-throw]
    N -- options.catch false --> O
    N -- catch mode on, not ResourceLimitError --> P[log and swallow]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve legacy recursion limit disablem..."](https://github.com/xpadev-net/niwango-core.js/commit/beec9d28da6b958a39118dbdcf1c4c816d12def9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39457812)</sub>

<!-- /greptile_comment -->