### PR TITLE
Prevent prototype pollution through script slots

### DIFF
--- a/src/__tests__/Object.test.ts
+++ b/src/__tests__/Object.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { run } from "@/testUtils";
+
+const objectPrototype = Object.prototype as Record<string, unknown>;
+
+afterEach(() => {
+  delete objectPrototype.polluted;
+  delete objectPrototype.pollutedCall;
+});
+
+const withMutedConsole = <T>(callback: () => T): T => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  try {
+    return callback();
+  } finally {
+    consoleError.mockRestore();
+    consoleLog.mockRestore();
+  }
+};
 
 describe("Object.prototype", () => {
   test("def", () => {
@@ -48,5 +66,72 @@ describe("Object.prototype", () => {
         "obj=Object.clone;obj.def(test(),self.hoge=1);obj2=Object.clone;obj2.def(test(),self.hoge=obj.clone;hoge.test());obj2.test();obj2.hoge.hoge",
       ),
     ).toBe(1);
+  });
+
+  test("dangerous member writes cannot pollute host prototypes", () => {
+    withMutedConsole(() => {
+      run("hoge={};hoge.__proto__.polluted=1");
+      expect(objectPrototype.polluted).toBeUndefined();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+      run("hoge={};hoge.constructor.prototype.polluted=1");
+      expect(objectPrototype.polluted).toBeUndefined();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+      run("hoge={};hoge.prototype=1");
+      expect(run("hoge={};hoge.prototype")).toBeUndefined();
+    });
+  });
+
+  test("object literal and slot APIs reject dangerous slot names", () => {
+    expect(run("hoge={__proto__:{polluted:1}};hoge.__proto__")).toBeUndefined();
+    expect(run("hoge={prototype:1};hoge.prototype")).toBeUndefined();
+    expect(run('hoge={};hoge.setSlot("__proto__",256)')).toBeUndefined();
+    expect(run('hoge={};hoge.setSlot("prototype",256)')).toBeUndefined();
+    expect(run('hoge={};hoge.getSlot("__proto__")')).toBeUndefined();
+    expect(run('hoge={};hoge.getSlot("prototype")')).toBeUndefined();
+
+    run('hoge={};hoge.setSlot("constructor",{prototype:{polluted:1}})');
+    expect(objectPrototype.polluted).toBeUndefined();
+  });
+
+  test("scope lookup cannot resolve dangerous inherited names", () => {
+    withMutedConsole(() => {
+      run("__proto__.polluted=1");
+      expect(objectPrototype.polluted).toBeUndefined();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
+  test("dangerous script-defined names are unreachable", () => {
+    expect(
+      run('hoge={};hoge.def_kari("__proto__","bad");hoge.__proto__'),
+    ).toBeUndefined();
+    expect(
+      run('hoge={};hoge.def(__proto__(),"bad");hoge.__proto__'),
+    ).toBeUndefined();
+  });
+
+  test("dangerous function parameters do not shift positional arguments", () => {
+    expect(run("def(hoge(__proto__,safe),safe);hoge(1,2)")).toBe(2);
+    expect(run("def(hoge(prototype,safe),safe);hoge(1,2)")).toBe(2);
+  });
+
+  test("call dispatch ignores inherited host and invalid computed slots", () => {
+    withMutedConsole(() => {
+      objectPrototype.pollutedCall = () => 1;
+      expect(
+        run("hoge={};hoge.pollutedCall()", { catch: true }),
+      ).toBeUndefined();
+    });
+
+    expect(run('array=[];array[["constructor"]]')).toBeUndefined();
+    expect(run('array=[];array[["__proto__"]]')).toBeUndefined();
+    expect(
+      run('array=[];array[["constructor"]]()', { catch: true }),
+    ).toBeUndefined();
+    expect(
+      run('array=[];array[["__proto__"]]()', { catch: true }),
+    ).toBeUndefined();
   });
 });

--- a/src/processors/CallExpression.ts
+++ b/src/processors/CallExpression.ts
@@ -2,6 +2,7 @@ import type {
   A_ANY,
   A_CallExpression,
   A_MemberExpression,
+  Argument,
   T_scope,
 } from "@/@types/ast";
 import type {
@@ -9,8 +10,8 @@ import type {
   definedKariFunction,
   definedNormalFunction,
 } from "@/@types/function";
+import type { IrFunction } from "@/@types/functions";
 import {
-  argumentParser,
   definedFunctions,
   execute,
   getName,
@@ -21,53 +22,77 @@ import { functions } from "@/functions";
 import { getType } from "@/prototype/getType";
 import typeGuard from "@/typeGuard";
 import { getGlobalScope, resolve } from "@/utils";
+import {
+  createSlotStore,
+  getOwnSlot,
+  normalizeSlotKey,
+  type SlotKey,
+  type SlotStore,
+  setOwnSlot,
+} from "@/utils/slot";
 
 const processCallExpression = (
   script: A_CallExpression,
   scopes: T_scope[],
   trace: A_ANY[],
 ) => {
-  const isMemberExpression = typeGuard.MemberExpression(script.callee);
-  const callee = getName(
-    isMemberExpression
-      ? (script.callee as A_MemberExpression).property
-      : script.callee,
-    scopes,
-    trace,
-  ) as string;
+  const callee = getCallee(script, scopes, trace);
+  if (callee === undefined) {
+    return;
+  }
   const object = getThis(script, scopes, trace);
-  const objectRef = object?.[callee];
+  const objectRef = getOwnSlot(object, callee);
   if (typeGuard.definedFunction(objectRef)) {
     return processDefinedFunction(script, scopes, trace, objectRef, object);
   }
-  const objectCallRef = (object?.[callee] as { [k: string]: unknown })?.call;
+  const objectCallRef = getOwnSlot(objectRef, "call");
   if (typeGuard.definedFunction(objectCallRef)) {
     return processDefinedFunction(script, scopes, trace, objectCallRef, object);
   }
   const self = resolve({ type: "Identifier", name: "self" }, scopes, trace) as {
     [key: string]: unknown;
   };
-  const selfRef = self?.[callee];
+  const selfRef = getOwnSlot(self, callee);
   if (typeGuard.definedFunction(selfRef)) {
     return processDefinedFunction(script, scopes, trace, selfRef);
   }
-  const selfCallRef = (self?.[callee] as { [k: string]: unknown })?.call;
+  const selfCallRef = getOwnSlot(selfRef, "call");
   if (typeGuard.definedFunction(selfCallRef)) {
     return processDefinedFunction(script, scopes, trace, selfCallRef);
   }
-  const prototype = resolvePrototype(getType(object), callee);
-  if (prototype) {
-    return prototype(script, scopes, object, trace);
-  }
-  const func = functions[callee];
-  if (func) {
-    return func(script, scopes, object, trace);
-  }
-  const definedFunc = definedFunctions[callee];
-  if (definedFunc) {
-    return definedFunc(script, scopes, object, trace);
+  if (typeof callee === "string") {
+    const prototype = resolvePrototype(getType(object), callee);
+    if (prototype) {
+      return prototype(script, scopes, object, trace);
+    }
+    const func = getOwnSlot(functions, callee) as IrFunction | undefined;
+    if (func) {
+      return func(script, scopes, object, trace);
+    }
+    const definedFunc = getOwnSlot(definedFunctions, callee) as
+      | IrFunction
+      | undefined;
+    if (definedFunc) {
+      return definedFunc(script, scopes, object, trace);
+    }
   }
   throw new NotImplementedError(script, scopes);
+};
+
+const getCallee = (
+  script: A_CallExpression,
+  scopes: T_scope[],
+  trace: A_ANY[],
+): SlotKey | undefined => {
+  if (typeGuard.MemberExpression(script.callee)) {
+    const callee = script.callee as A_MemberExpression;
+    return normalizeSlotKey(
+      callee.computed
+        ? execute(callee.property, scopes, trace)
+        : getName(callee.property, scopes, trace),
+    );
+  }
+  return normalizeSlotKey(getName(script.callee, scopes, trace));
 };
 
 const processDefinedFunction = (
@@ -90,17 +115,17 @@ const processDefinedKariFunction = (
   trace: A_ANY[],
   func: definedKariFunction,
 ) => {
-  const args: { [key: string]: unknown } = {};
+  const args = createSlotStore();
   let count = 1;
   script.arguments.forEach((val) => {
     if (val?.NIWANGO_Identifier) {
-      args[getName(val.NIWANGO_Identifier, scopes, trace) as string] = execute(
-        val,
-        scopes,
-        trace,
+      setOwnSlot(
+        args,
+        normalizeSlotKey(getName(val.NIWANGO_Identifier, scopes, trace)),
+        execute(val, scopes, trace),
       );
     } else {
-      args[`$${count++}`] = execute(val, scopes, trace);
+      setOwnSlot(args, `$${count++}`, execute(val, scopes, trace));
     }
   });
   return execute(func.script.arguments[1], [args, ...scopes], trace);
@@ -113,14 +138,62 @@ const processDefinedNormalFunction = (
   func: definedNormalFunction,
   object?: { [k: string]: unknown },
 ) => {
-  const argNames = func.script.arguments[0].arguments.map(
-    (arg) => getName(arg, scopes, trace) as string,
+  const argNames = func.script.arguments[0].arguments
+    .map((arg) => getName(arg, scopes, trace) as string)
+    .filter((argName) => typeof argName === "string");
+  const scopeValues = parseDefinedFunctionArguments(
+    script.arguments,
+    scopes,
+    argNames,
+    trace,
   );
-  const args = argumentParser(script.arguments, scopes, argNames, trace);
   const scope = object
-    ? [{ ...args, self: object }, object, ...scopes]
-    : [{ ...args }, ...scopes];
+    ? [setScopeSelf(scopeValues, object), object, ...scopes]
+    : [scopeValues, ...scopes];
   return execute(func.script.arguments[1], scope, trace);
+};
+
+const parseDefinedFunctionArguments = (
+  inputs: Argument<A_ANY>[],
+  scopes: T_scope[],
+  keys: string[],
+  trace: A_ANY[],
+): SlotStore => {
+  const result = createSlotStore();
+  const assignedKeys = new Set<string>();
+  const nonKeyValues: Argument<A_ANY>[] = [];
+
+  for (const item of inputs) {
+    if (item.NIWANGO_Identifier) {
+      const key = getName(item.NIWANGO_Identifier, scopes, trace);
+      if (typeof key === "string" && keys.includes(key)) {
+        assignedKeys.add(key);
+        setOwnSlot(result, normalizeSlotKey(key), execute(item, scopes, trace));
+        continue;
+      }
+    }
+    nonKeyValues.push(item);
+  }
+
+  let i = 0;
+  for (const key of keys) {
+    const value = nonKeyValues[i];
+    if (!assignedKeys.has(key) && value) {
+      assignedKeys.add(key);
+      setOwnSlot(result, normalizeSlotKey(key), execute(value, scopes, trace));
+      i++;
+    }
+  }
+
+  return result;
+};
+
+const setScopeSelf = (
+  scope: SlotStore,
+  object: { [k: string]: unknown },
+): SlotStore => {
+  setOwnSlot(scope, "self", object);
+  return scope;
 };
 /**
  * 参照を取るための関数

--- a/src/processors/CallExpression.ts
+++ b/src/processors/CallExpression.ts
@@ -31,6 +31,11 @@ import {
   setOwnSlot,
 } from "@/utils/slot";
 
+type DefinedFunctionParameter = {
+  name: string;
+  slotKey: SlotKey | undefined;
+};
+
 const processCallExpression = (
   script: A_CallExpression,
   scopes: T_scope[],
@@ -138,13 +143,22 @@ const processDefinedNormalFunction = (
   func: definedNormalFunction,
   object?: { [k: string]: unknown },
 ) => {
-  const argNames = func.script.arguments[0].arguments
-    .map((arg) => getName(arg, scopes, trace) as string)
-    .filter((argName) => typeof argName === "string");
+  const parameters = func.script.arguments[0].arguments
+    .map((arg): DefinedFunctionParameter | undefined => {
+      const name = getName(arg, scopes, trace);
+      if (typeof name !== "string") {
+        return undefined;
+      }
+      return {
+        name,
+        slotKey: normalizeSlotKey(name),
+      };
+    })
+    .filter((argName) => argName !== undefined);
   const scopeValues = parseDefinedFunctionArguments(
     script.arguments,
     scopes,
-    argNames,
+    parameters,
     trace,
   );
   const scope = object
@@ -156,7 +170,7 @@ const processDefinedNormalFunction = (
 const parseDefinedFunctionArguments = (
   inputs: Argument<A_ANY>[],
   scopes: T_scope[],
-  keys: string[],
+  parameters: DefinedFunctionParameter[],
   trace: A_ANY[],
 ): SlotStore => {
   const result = createSlotStore();
@@ -166,21 +180,24 @@ const parseDefinedFunctionArguments = (
   for (const item of inputs) {
     if (item.NIWANGO_Identifier) {
       const key = getName(item.NIWANGO_Identifier, scopes, trace);
-      if (typeof key === "string" && keys.includes(key)) {
-        assignedKeys.add(key);
-        setOwnSlot(result, normalizeSlotKey(key), execute(item, scopes, trace));
-        continue;
+      if (typeof key === "string") {
+        const parameter = parameters.find((param) => param.name === key);
+        if (parameter) {
+          assignedKeys.add(key);
+          setOwnSlot(result, parameter.slotKey, execute(item, scopes, trace));
+          continue;
+        }
       }
     }
     nonKeyValues.push(item);
   }
 
   let i = 0;
-  for (const key of keys) {
+  for (const parameter of parameters) {
     const value = nonKeyValues[i];
-    if (!assignedKeys.has(key) && value) {
-      assignedKeys.add(key);
-      setOwnSlot(result, normalizeSlotKey(key), execute(value, scopes, trace));
+    if (!assignedKeys.has(parameter.name) && value) {
+      assignedKeys.add(parameter.name);
+      setOwnSlot(result, parameter.slotKey, execute(value, scopes, trace));
       i++;
     }
   }

--- a/src/processors/MemberExpression.ts
+++ b/src/processors/MemberExpression.ts
@@ -3,7 +3,12 @@ import type { definedFunction } from "@/@types/function";
 import { execute, getName } from "@/context";
 import { processCallExpression } from "@/processors/CallExpression";
 import typeGuard from "@/typeGuard";
-import { getOwnSlot, normalizeSlotKey } from "@/utils/slot";
+import {
+  createSlotStore,
+  getOwnSlot,
+  normalizeSlotKey,
+  setOwnSlot,
+} from "@/utils/slot";
 
 /**
  * 配列やオブジェクトを処理する
@@ -38,20 +43,24 @@ const processMemberExpression = (
     const func = leftSlot as definedFunction;
     return execute(
       func.script.arguments[1],
-      [{ self: left }, ...scopes],
+      [createSelfScope(left), ...scopes],
       trace,
     );
   }
   if (typeGuard.LambdaExpression(left)) {
     if (typeGuard.SequenceExpression(script.property)) {
-      const args: { [key: string]: unknown } = {};
+      const args = createSlotStore();
       let index = 0;
       for (const arg of script.property.expressions) {
-        args[`@${index++}`] = execute(arg, scopes, trace);
+        setOwnSlot(args, `@${index++}`, execute(arg, scopes, trace));
       }
       return execute(left.body, [args, ...left.scopes], trace);
     }
-    return execute(left.body, [{ "@0": right }, ...left.scopes], trace);
+    return execute(
+      left.body,
+      [createSlotScope("@0", right), ...left.scopes],
+      trace,
+    );
   }
   try {
     return processCallExpression(
@@ -71,12 +80,22 @@ const processMemberExpression = (
         },
         arguments: [],
       },
-      [{ self: left }, ...scopes],
+      [createSelfScope(left), ...scopes],
       trace,
     );
   } catch (_e) {
     return getOwnSlot(left, right);
   }
+};
+
+const createSelfScope = (self: unknown) => {
+  return createSlotScope("self", self);
+};
+
+const createSlotScope = (key: string | number, value: unknown) => {
+  const scope = createSlotStore();
+  setOwnSlot(scope, key, value);
+  return scope;
 };
 
 export { processMemberExpression };

--- a/src/processors/MemberExpression.ts
+++ b/src/processors/MemberExpression.ts
@@ -3,6 +3,7 @@ import type { definedFunction } from "@/@types/function";
 import { execute, getName } from "@/context";
 import { processCallExpression } from "@/processors/CallExpression";
 import typeGuard from "@/typeGuard";
+import { getOwnSlot, normalizeSlotKey } from "@/utils/slot";
 
 /**
  * 配列やオブジェクトを処理する
@@ -24,13 +25,17 @@ const processMemberExpression = (
     );
     return;
   }
-  const right = (
+  const right = normalizeSlotKey(
     script.computed
       ? execute(script.property, scopes, trace)
-      : getName(script.property, scopes, trace)
-  ) as string | number;
-  if (typeGuard.object(left) && typeGuard.definedFunction(left[right])) {
-    const func = left[right] as definedFunction;
+      : getName(script.property, scopes, trace),
+  );
+  if (right === undefined) {
+    return;
+  }
+  const leftSlot = getOwnSlot(left, right);
+  if (typeGuard.object(left) && typeGuard.definedFunction(leftSlot)) {
+    const func = leftSlot as definedFunction;
     return execute(
       func.script.arguments[1],
       [{ self: left }, ...scopes],
@@ -70,7 +75,7 @@ const processMemberExpression = (
       trace,
     );
   } catch (_e) {
-    return (left as { [key: string]: unknown })[right];
+    return getOwnSlot(left, right);
   }
 };
 

--- a/src/processors/ObjectExpression.ts
+++ b/src/processors/ObjectExpression.ts
@@ -1,5 +1,6 @@
 import type { A_ANY, A_ObjectExpression, T_scope } from "@/@types/ast";
 import { execute, getName } from "@/context";
+import { createSlotStore, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 /**
  * オブジェクトを作成する
@@ -11,13 +12,11 @@ const processObjectExpression = (
   scopes: T_scope[],
   trace: A_ANY[],
 ) => {
-  const object: { [key: string | number | symbol]: unknown } = {};
+  const object = createSlotStore();
   for (const item of script.properties) {
-    object[getName(item.key, scopes, trace) as string] = execute(
-      item.value,
-      scopes,
-      trace,
-    );
+    const key = normalizeSlotKey(getName(item.key, scopes, trace));
+    const value = execute(item.value, scopes, trace);
+    setOwnSlot(object, key, value);
   }
   return object;
 };

--- a/src/prototype/Object/def.ts
+++ b/src/prototype/Object/def.ts
@@ -3,6 +3,7 @@ import type { definedFunction } from "@/@types/function";
 import { getName } from "@/context";
 import { InvalidTypeError } from "@/errors/InvalidTypeError";
 import typeGuard from "@/typeGuard";
+import { normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 import type { PrototypeObjectFunction } from "./index";
 
@@ -35,11 +36,11 @@ const processDef: PrototypeObjectFunction = (
   if (typeof functionName !== "string") {
     throw new InvalidTypeError("function name must be string", script, scopes);
   }
-  object[functionName] = {
+  setOwnSlot(object, normalizeSlotKey(functionName), {
     type: "definedFunction",
     isKari: false,
     script,
-  } as definedFunction;
+  } as definedFunction);
 };
 
 export { processDef };

--- a/src/prototype/Object/def_kari.ts
+++ b/src/prototype/Object/def_kari.ts
@@ -2,6 +2,7 @@ import type { A_ANY } from "@/@types";
 import type { definedFunction } from "@/@types/function";
 import { execute } from "@/context";
 import type { PrototypeObjectFunction } from "@/prototype/Object/index";
+import { normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 /**
  * @関数
@@ -23,11 +24,11 @@ const processDefKari: PrototypeObjectFunction = (
   if (typeof functionName !== "string") {
     return;
   }
-  object[functionName] = {
+  setOwnSlot(object, normalizeSlotKey(functionName), {
     type: "definedFunction",
     isKari: true,
     script,
-  } as definedFunction;
+  } as definedFunction);
 };
 
 export { processDefKari };

--- a/src/prototype/Object/getSlot.ts
+++ b/src/prototype/Object/getSlot.ts
@@ -1,6 +1,7 @@
 import type { A_ANY } from "@/@types";
 import { execute } from "@/context";
 import { InvalidTypeError } from "@/errors/InvalidTypeError";
+import { getOwnSlot, normalizeSlotKey } from "@/utils/slot";
 
 import type { PrototypeObjectFunction } from "./index";
 
@@ -25,7 +26,7 @@ const processGetSlot: PrototypeObjectFunction = (
       scopes,
     );
   }
-  return object[key];
+  return getOwnSlot(object, normalizeSlotKey(key));
 };
 
 export { processGetSlot };

--- a/src/prototype/Object/setSlot.ts
+++ b/src/prototype/Object/setSlot.ts
@@ -1,6 +1,7 @@
 import type { A_ANY } from "@/@types";
 import { execute } from "@/context";
 import { InvalidTypeError } from "@/errors/InvalidTypeError";
+import { normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 import type { PrototypeObjectFunction } from "./index";
 
@@ -26,7 +27,9 @@ const processSetSlot: PrototypeObjectFunction = (
     );
   }
   const value = execute(script.arguments[1], scopes, trace);
-  object[key] = value;
+  if (!setOwnSlot(object, normalizeSlotKey(key), value)) {
+    return;
+  }
   return value;
 };
 

--- a/src/prototype/resolve.ts
+++ b/src/prototype/resolve.ts
@@ -6,35 +6,57 @@ import { prototypeNumberFunctions } from "@/prototype/Number";
 import { prototypeObjectFunctions } from "@/prototype/Object";
 import { prototypeStringFunctions } from "@/prototype/String";
 import { prototypeValueFunctions } from "@/prototype/Value";
+import { getOwnSlot, normalizeSlotKey } from "@/utils/slot";
 
 const resolvePrototype: ResolvePrototype = (type, name) => {
-  if (
-    (type === "object" || type === "array") &&
-    prototypeObjectFunctions[name]
-  ) {
-    return prototypeObjectFunctions[name] as ResolveResult;
-  } else if (type === "array" && prototypeArrayFunctions[name]) {
-    return prototypeArrayFunctions[name] as ResolveResult;
-  } else if (type === "string" && prototypeStringFunctions[name]) {
-    return prototypeStringFunctions[name] as ResolveResult;
-  } else if (type === "boolean" && prototypeBoolFunctions[name]) {
-    return prototypeBoolFunctions[name] as ResolveResult;
-  } else if (type === "number" && prototypeNumberFunctions[name]) {
-    return prototypeNumberFunctions[name] as ResolveResult;
-  } else if (prototypeValueFunctions[name]) {
-    return prototypeValueFunctions[name] as ResolveResult;
+  const key = normalizeSlotKey(name);
+  if (key === undefined || typeof key !== "string") {
+    return undefined;
   }
 
-  if (type === "array" && prototypeScope.Array[name]) {
-    return prototypeScope.Array[name] as ResolveResult;
-  } else if (type === "string" && prototypeScope.String[name]) {
-    return prototypeScope.String[name] as ResolveResult;
-  } else if (type === "boolean" && prototypeScope.Bool[name]) {
-    return prototypeScope.Bool[name] as ResolveResult;
-  } else if (type === "number" && prototypeScope.Number[name]) {
-    return prototypeScope.Number[name] as ResolveResult;
-  } else if (type === "object" && prototypeScope.Object[name]) {
-    return prototypeScope.Object[name] as ResolveResult;
+  if (type === "object" || type === "array") {
+    const objectPrototype = getOwnSlot(prototypeObjectFunctions, key);
+    if (objectPrototype) {
+      return objectPrototype as ResolveResult;
+    }
+  }
+  if (type === "array") {
+    const arrayPrototype = getOwnSlot(prototypeArrayFunctions, key);
+    if (arrayPrototype) {
+      return arrayPrototype as ResolveResult;
+    }
+  } else if (type === "string") {
+    const stringPrototype = getOwnSlot(prototypeStringFunctions, key);
+    if (stringPrototype) {
+      return stringPrototype as ResolveResult;
+    }
+  } else if (type === "boolean") {
+    const boolPrototype = getOwnSlot(prototypeBoolFunctions, key);
+    if (boolPrototype) {
+      return boolPrototype as ResolveResult;
+    }
+  } else if (type === "number") {
+    const numberPrototype = getOwnSlot(prototypeNumberFunctions, key);
+    if (numberPrototype) {
+      return numberPrototype as ResolveResult;
+    }
+  }
+
+  const valuePrototype = getOwnSlot(prototypeValueFunctions, key);
+  if (valuePrototype) {
+    return valuePrototype as ResolveResult;
+  }
+
+  if (type === "array") {
+    return getOwnSlot(prototypeScope.Array, key) as ResolveResult;
+  } else if (type === "string") {
+    return getOwnSlot(prototypeScope.String, key) as ResolveResult;
+  } else if (type === "boolean") {
+    return getOwnSlot(prototypeScope.Bool, key) as ResolveResult;
+  } else if (type === "number") {
+    return getOwnSlot(prototypeScope.Number, key) as ResolveResult;
+  } else if (type === "object") {
+    return getOwnSlot(prototypeScope.Object, key) as ResolveResult;
   }
   return undefined;
 };

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -1,6 +1,7 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 import { execute, getName, setAssign } from "@/context";
 import typeGuard from "@/typeGuard";
+import { getOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 /**
  * 変数に代入する関数
@@ -19,14 +20,18 @@ const assign = (
   }
   try {
     if (typeGuard.Identifier(target)) {
+      const key = normalizeSlotKey(target.name);
+      if (key === undefined) {
+        return;
+      }
       for (const scope of scopes) {
-        if (scope[target.name] !== undefined) {
-          scope[target.name] = value;
+        if (getOwnSlot(scope, key) !== undefined) {
+          setOwnSlot(scope, key, value);
           return;
         }
       }
       if (scopes[0]) {
-        scopes[0][target.name] = value;
+        setOwnSlot(scopes[0], key, value);
       }
     } else if (typeGuard.MemberExpression(target)) {
       const left = execute(target.object, scopes, trace);
@@ -40,12 +45,12 @@ const assign = (
         );
         return;
       }
-      const key = (
+      const key = normalizeSlotKey(
         target.computed
           ? execute(target.property, scopes, trace)
-          : getName(target.property, scopes, trace)
-      ) as string;
-      left[key] = value;
+          : getName(target.property, scopes, trace),
+      );
+      setOwnSlot(left, key, value);
     }
   } catch (e) {
     if (e instanceof Error) {

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -1,6 +1,7 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 import { resultHook } from "@/context";
 import typeGuard from "@/typeGuard";
+import { getOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 /**
  * 変数の参照を取得する関数
@@ -11,9 +12,13 @@ import typeGuard from "@/typeGuard";
 const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
   try {
     if (typeGuard.Identifier(script)) {
+      const key = normalizeSlotKey(script.name);
+      if (key === undefined || typeof key !== "string") {
+        return undefined;
+      }
       for (const scope of scopes) {
-        if (scope[script.name] !== undefined) {
-          return processResolveHook(scope, script.name);
+        if (getOwnSlot(scope, key) !== undefined) {
+          return processResolveHook(scope, key);
         }
       }
     }
@@ -26,11 +31,11 @@ const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
 };
 
 const processResolveHook = (scope: T_scope, name: string) => {
-  let value = scope[name];
+  let value = getOwnSlot(scope, name);
   for (const hook of resultHook) {
     value = hook(value);
   }
-  scope[name] = value;
+  setOwnSlot(scope, name, value);
   return value;
 };
 

--- a/src/utils/slot.ts
+++ b/src/utils/slot.ts
@@ -60,6 +60,9 @@ const setOwnSlot = (
   if (key === undefined || !isSlotStore(target)) {
     return false;
   }
+  if (typeof key === "string" && dangerousSlotNames.has(key)) {
+    return false;
+  }
   target[key] = value;
   return true;
 };

--- a/src/utils/slot.ts
+++ b/src/utils/slot.ts
@@ -1,0 +1,68 @@
+type SlotKey = string | number;
+type SlotStore = {
+  [key: string | number]: unknown;
+};
+
+const dangerousSlotNames = new Set(["__proto__", "constructor", "prototype"]);
+
+const createSlotStore = (): SlotStore => {
+  return Object.create(null) as SlotStore;
+};
+
+const isSlotStore = (value: unknown): value is SlotStore => {
+  return (
+    (typeof value === "object" && value !== null) || typeof value === "function"
+  );
+};
+
+const getReadableSlotStore = (value: unknown): SlotStore | undefined => {
+  if (isSlotStore(value)) {
+    return value;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return Object(value) as SlotStore;
+  }
+  return undefined;
+};
+
+const normalizeSlotKey = (key: unknown): SlotKey | undefined => {
+  if (typeof key !== "string" && typeof key !== "number") {
+    return undefined;
+  }
+  if (typeof key === "string" && dangerousSlotNames.has(key)) {
+    return undefined;
+  }
+  return key;
+};
+
+const getOwnSlot = (target: unknown, key: SlotKey | undefined): unknown => {
+  const slotStore = getReadableSlotStore(target);
+  if (key === undefined || !slotStore) {
+    return undefined;
+  }
+  if (!Object.hasOwn(slotStore, key)) {
+    return undefined;
+  }
+  return slotStore[key];
+};
+
+const setOwnSlot = (
+  target: unknown,
+  key: SlotKey | undefined,
+  value: unknown,
+): boolean => {
+  if (key === undefined || !isSlotStore(target)) {
+    return false;
+  }
+  target[key] = value;
+  return true;
+};
+
+export { createSlotStore, getOwnSlot, normalizeSlotKey, setOwnSlot };
+export type { SlotKey, SlotStore };


### PR DESCRIPTION
## Summary
- add centralized slot-key normalization and own-slot access helpers
- use null-prototype stores for script object literals and defined-function scopes
- guard member lookup, assignment, prototype resolution, Object slot helpers, def/def_kari, and call dispatch from dangerous or inherited slots
- add prototype-pollution regressions for __proto__, constructor, prototype, inherited calls, invalid computed keys, and dangerous function parameters

## Validation
- npm test -- src/__tests__/Object.test.ts --run
- npm run lint
- npm run check-types
- npm test -- --run
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- deep-review self-review performed
- independent security/boundary review: no actionable findings after prototype coverage was added
- independent tests/failure-semantics review: initial positional-argument finding fixed; follow-up reported no required findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens niwango-core against prototype pollution by introducing a centralized `slot.ts` utility module with null-prototype stores, safe key normalization, and own-property-only read/write helpers — then wires them into every site that creates script objects, writes scope entries, resolves identifiers, dispatches calls, or sets member expressions.

- **`src/utils/slot.ts`** (new): `createSlotStore()` (null-prototype objects), `normalizeSlotKey()` (rejects `__proto__`/`constructor`/`prototype` + non-string/number), `getOwnSlot()` (`Object.hasOwn`-based), and `setOwnSlot()` (internal guard redundant with normalization, defense-in-depth).
- **All processors and prototype helpers** (`ObjectExpression`, `MemberExpression`, `CallExpression`, `assign`, `resolve`, `def`, `def_kari`, `getSlot`, `setSlot`, `resolvePrototype`) updated to route through the new helpers instead of direct bracket access.
- **`src/__tests__/Object.test.ts`**: seven regression tests covering `__proto__`/`constructor`/`prototype` across writes, object literals, slot APIs, scope lookup, defined-function names, parameter positions, and call dispatch.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all write and read paths through the script runtime now funnel through null-prototype stores and key normalization, with defense-in-depth guards at both the normalization layer and inside `setOwnSlot`.

Every mutation point (object literals, member assignment, scope writes, `def`/`def_kari`, `setSlot`) now rejects dangerous key names before touching storage. Read paths use `Object.hasOwn`, making inherited host properties invisible. The regression test suite directly verifies the pollution vectors across six distinct attack surfaces. No existing behavior regression was introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/utils/slot.ts | New centralized security module; `normalizeSlotKey` and `setOwnSlot` both guard dangerous names (defense-in-depth), `getOwnSlot` relies on `Object.hasOwn` semantics for safety — correct given no write path can create `__proto__` as a true own property. |
| src/processors/CallExpression.ts | Callee normalization, slot-safe kari/normal function arg dispatch, and `getOwnSlot` for `functions`/`definedFunctions` lookup all correctly route through new helpers; dangerous param names consume positional slots without binding (tested). |
| src/processors/MemberExpression.ts | Right-hand side key normalized before use; `createSlotScope` replaces plain `{ self: left }` and `{ "@0": right }` objects with null-prototype stores; catch-path now uses `getOwnSlot` instead of direct bracket access. |
| src/utils/assign.ts | Both Identifier and MemberExpression assignment paths now normalize keys and use `setOwnSlot`; dangerous identifier assignments silently return without mutation. |
| src/utils/resolve.ts | Identifier resolution guards against dangerous names and uses `Object.hasOwn` for scope lookup; `processResolveHook` updated to use `getOwnSlot`/`setOwnSlot`. |
| src/__tests__/Object.test.ts | Seven new regression tests cover the major pollution vectors; `afterEach` cleanup is scoped to the two property names actually used, which is correct. |
| src/processors/ObjectExpression.ts | Object literals now use null-prototype store; key normalization discards dangerous property names before write. |
| src/prototype/resolve.ts | Prototype dispatch normalized through `normalizeSlotKey` and `getOwnSlot`; correctly rejects numeric keys for prototype method lookup via `typeof key !== 'string'` guard. |
| src/prototype/Object/def.ts | Function-definition write now routed through `setOwnSlot` + `normalizeSlotKey`; dangerous function names are silently dropped. |
| src/prototype/Object/def_kari.ts | Same pattern as `def.ts`; dangerous names silently no-op through `setOwnSlot(obj, undefined, ...)`. |
| src/prototype/Object/getSlot.ts | Slot key normalized before `getOwnSlot`; dangerous names return `undefined`. |
| src/prototype/Object/setSlot.ts | Slot key normalized before `setOwnSlot`; returns early on failure, no longer returns the value for failed writes. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Script Input] --> B{Expression Type}

    B -->|Identifier| C[resolve.ts]
    B -->|MemberExpression| D[MemberExpression.ts]
    B -->|AssignmentExpression| E[assign.ts]
    B -->|CallExpression| F[CallExpression.ts]
    B -->|ObjectExpression| G[ObjectExpression.ts]

    C --> N[normalizeSlotKey]
    D --> N
    E --> N
    F --> N
    G --> N

    N -->|dangerous name| BLOCK[return undefined / no-op]
    N -->|non-string non-number| BLOCK
    N -->|safe key| SAFE[SlotKey]

    SAFE --> OWN{Read or Write?}
    OWN -->|Read| GOWN[getOwnSlot - Object.hasOwn check]
    OWN -->|Write| SOWN[setOwnSlot - dangerousSlotNames guard]

    GOWN --> SLOT[SlotStore - null-prototype object]
    SOWN --> SLOT

    SLOT -->|No prototype chain| HOST_SAFE[Host Object.prototype unreachable]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Script Input] --> B{Expression Type}

    B -->|Identifier| C[resolve.ts]
    B -->|MemberExpression| D[MemberExpression.ts]
    B -->|AssignmentExpression| E[assign.ts]
    B -->|CallExpression| F[CallExpression.ts]
    B -->|ObjectExpression| G[ObjectExpression.ts]

    C --> N[normalizeSlotKey]
    D --> N
    E --> N
    F --> N
    G --> N

    N -->|dangerous name| BLOCK[return undefined / no-op]
    N -->|non-string non-number| BLOCK
    N -->|safe key| SAFE[SlotKey]

    SAFE --> OWN{Read or Write?}
    OWN -->|Read| GOWN[getOwnSlot - Object.hasOwn check]
    OWN -->|Write| SOWN[setOwnSlot - dangerousSlotNames guard]

    GOWN --> SLOT[SlotStore - null-prototype object]
    SOWN --> SLOT

    SLOT -->|No prototype chain| HOST_SAFE[Host Object.prototype unreachable]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/processors/MemberExpression.ts`, line 38-43 ([link](https://github.com/xpadev-net/niwango-core.js/blob/a0227243c5273d4f9492f388c8477e988982b5d0/src/processors/MemberExpression.ts#L38-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inline scope object still uses prototype-inheriting plain object**

   When a `definedFunction` is found in a slot and executed, the scope entry is created as `{ self: left }` — a regular prototype-inheriting object — not a `SlotStore`. All other scope entries created in this PR use `createSlotStore()` (null-prototype). Because `resolve.ts` uses `getOwnSlot` (which calls `Object.hasOwn`), inherited keys from `Object.prototype` are invisible, so there is no current security hole. But the inconsistency means this scope entry behaves differently from all others during `Object.keys` / `for...in` style introspection and can be confusing. Using `createSlotStore()` and setting `"self"` via `setOwnSlot` (the same pattern `setScopeSelf` uses) would make scope construction uniform.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/processors/MemberExpression.ts
   Line: 38-43

   Comment:
   **Inline scope object still uses prototype-inheriting plain object**

   When a `definedFunction` is found in a slot and executed, the scope entry is created as `{ self: left }` — a regular prototype-inheriting object — not a `SlotStore`. All other scope entries created in this PR use `createSlotStore()` (null-prototype). Because `resolve.ts` uses `getOwnSlot` (which calls `Object.hasOwn`), inherited keys from `Object.prototype` are invisible, so there is no current security hole. But the inconsistency means this scope entry behaves differently from all others during `Object.keys` / `for...in` style introspection and can be confusing. Using `createSlotStore()` and setting `"self"` via `setOwnSlot` (the same pattern `setScopeSelf` uses) would make scope construction uniform.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fprocessors%2FMemberExpression.ts%0ALine%3A%2038-43%0A%0AComment%3A%0A**Inline%20scope%20object%20still%20uses%20prototype-inheriting%20plain%20object**%0A%0AWhen%20a%20%60definedFunction%60%20is%20found%20in%20a%20slot%20and%20executed%2C%20the%20scope%20entry%20is%20created%20as%20%60%7B%20self%3A%20left%20%7D%60%20%E2%80%94%20a%20regular%20prototype-inheriting%20object%20%E2%80%94%20not%20a%20%60SlotStore%60.%20All%20other%20scope%20entries%20created%20in%20this%20PR%20use%20%60createSlotStore%28%29%60%20%28null-prototype%29.%20Because%20%60resolve.ts%60%20uses%20%60getOwnSlot%60%20%28which%20calls%20%60Object.hasOwn%60%29%2C%20inherited%20keys%20from%20%60Object.prototype%60%20are%20invisible%2C%20so%20there%20is%20no%20current%20security%20hole.%20But%20the%20inconsistency%20means%20this%20scope%20entry%20behaves%20differently%20from%20all%20others%20during%20%60Object.keys%60%20%2F%20%60for...in%60%20style%20introspection%20and%20can%20be%20confusing.%20Using%20%60createSlotStore%28%29%60%20and%20setting%20%60%22self%22%60%20via%20%60setOwnSlot%60%20%28the%20same%20pattern%20%60setScopeSelf%60%20uses%29%20would%20make%20scope%20construction%20uniform.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniwango-core.js&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Address slot review hardening"](https://github.com/xpadev-net/niwango-core.js/commit/54483fa1795675979dd8c025721cd7216edaca91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39459974)</sub>

<!-- /greptile_comment -->