### PR TITLE
Bound parser input and recovery

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -14,7 +14,7 @@ test("parseScript rejects oversized script input before parsing", () => {
   ).toThrow(ParserInputLimitError);
 });
 
-test("parseScript parses valid input below the configured size limit", () => {
+test("parseScript parses valid input at the configured size limit", () => {
   const script = "1+2";
 
   expect(
@@ -44,6 +44,22 @@ test("parseScript recovery stops at the configured recovery count", () => {
       }),
     ).toThrow(ParserRecoveryLimitError);
     expect(info).toHaveBeenCalledTimes(1);
+  } finally {
+    info.mockRestore();
+  }
+});
+
+test("parseScript recovery with zero attempts surfaces syntax errors", () => {
+  const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+  try {
+    expect(() =>
+      parseScript("1@+2", "parser.test", {
+        recoverSyntaxErrors: true,
+        maxRecoveryAttempts: 0,
+      }),
+    ).toThrow(PeggySyntaxError);
+    expect(info).not.toHaveBeenCalled();
   } finally {
     info.mockRestore();
   }

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,6 +1,26 @@
 import { expect, test, vi } from "vitest";
-import { parseScript } from "@/parser/parse";
+import {
+  ParserInputLimitError,
+  ParserRecoveryLimitError,
+  parseScript,
+} from "@/parser/parse";
 import { SyntaxError as PeggySyntaxError, parse } from "@/parser/parser";
+
+test("parseScript rejects oversized script input before parsing", () => {
+  const script = "1+2";
+
+  expect(() =>
+    parseScript(script, "parser.test", { maxInputLength: script.length - 1 }),
+  ).toThrow(ParserInputLimitError);
+});
+
+test("parseScript parses valid input below the configured size limit", () => {
+  const script = "1+2";
+
+  expect(
+    parseScript(script, "parser.test", { maxInputLength: script.length }),
+  ).toEqual(parse(script, { grammarSource: "parser.test" }));
+});
 
 test("parseScript surfaces syntax errors by default", () => {
   const info = vi.spyOn(console, "info").mockImplementation(() => {});
@@ -8,6 +28,22 @@ test("parseScript surfaces syntax errors by default", () => {
   try {
     expect(() => parseScript("1@+2", "parser.test")).toThrow(PeggySyntaxError);
     expect(info).not.toHaveBeenCalled();
+  } finally {
+    info.mockRestore();
+  }
+});
+
+test("parseScript recovery stops at the configured recovery count", () => {
+  const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+  try {
+    expect(() =>
+      parseScript("1@@+2", "parser.test", {
+        recoverSyntaxErrors: true,
+        maxRecoveryAttempts: 1,
+      }),
+    ).toThrow(ParserRecoveryLimitError);
+    expect(info).toHaveBeenCalledTimes(1);
   } finally {
     info.mockRestore();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,11 @@ import {
 } from "@/context";
 import * as Errors from "@/errors";
 import { initCore, resetCore } from "@/init";
-import { parseScript } from "@/parser/parse";
+import {
+  ParserInputLimitError,
+  ParserRecoveryLimitError,
+  parseScript,
+} from "@/parser/parse";
 import { format } from "@/utils/format";
 
 import { SyntaxError as PeggySyntaxError, parse } from "./parser/parser";
@@ -40,6 +44,8 @@ class NiwangoCore {
   static parseScript = parseScript;
   static parse = parse;
   static PeggySyntaxError = PeggySyntaxError;
+  static ParserInputLimitError = ParserInputLimitError;
+  static ParserRecoveryLimitError = ParserRecoveryLimitError;
   static appendDefinedFunctions = appendDefinedFunctions;
   static appendResultHook = appendResultHook;
   static setIsWide = setIsWide;

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -2,25 +2,96 @@ import type { A_ANY } from "@/@types/ast";
 
 import { SyntaxError as PeggySyntaxError, parse } from "./parser";
 
+const DEFAULT_PARSE_SCRIPT_MAX_INPUT_LENGTH = 65_536;
+const DEFAULT_PARSE_SCRIPT_MAX_RECOVERY_ATTEMPTS = 16;
+
+class ParserInputLimitError extends Error {
+  readonly inputLength: number;
+  readonly maxInputLength: number;
+
+  constructor(inputLength: number, maxInputLength: number) {
+    super(
+      `Parser input length ${inputLength} exceeds the configured maximum of ${maxInputLength}.`,
+    );
+    this.name = "ParserInputLimitError";
+    this.inputLength = inputLength;
+    this.maxInputLength = maxInputLength;
+  }
+}
+
+class ParserRecoveryLimitError extends Error {
+  readonly maxRecoveryAttempts: number;
+
+  constructor(maxRecoveryAttempts: number, cause: unknown) {
+    super(
+      `Parser syntax recovery stopped after ${maxRecoveryAttempts} attempt${
+        maxRecoveryAttempts === 1 ? "" : "s"
+      }.`,
+      { cause },
+    );
+    this.name = "ParserRecoveryLimitError";
+    this.maxRecoveryAttempts = maxRecoveryAttempts;
+  }
+}
+
+/**
+ * Budget controls for the synchronous parser wrapper. The generated parser is
+ * synchronous, so parseScript enforces deterministic size/recovery boundaries
+ * instead of an in-process wall-clock timeout.
+ */
 interface ParseScriptOptions {
   /** Re-enable the legacy Peggy syntax-error character deletion loop. */
   recoverSyntaxErrors?: boolean;
+  /** Maximum script length passed to the generated parser. */
+  maxInputLength?: number;
+  /** Maximum syntax-error character deletions when recovery is enabled. */
+  maxRecoveryAttempts?: number;
 }
+
+const resolveParserLimit = (
+  value: number | undefined,
+  defaultValue: number,
+  optionName: string,
+) => {
+  const limit = value ?? defaultValue;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new RangeError(`${optionName} must be a non-negative safe integer.`);
+  }
+  return limit;
+};
+
+const assertParserInputLength = (script: string, maxInputLength: number) => {
+  if (script.length > maxInputLength) {
+    throw new ParserInputLimitError(script.length, maxInputLength);
+  }
+};
 
 const parseScript = (
   content: string,
   name: string,
   options: ParseScriptOptions = {},
 ): A_ANY => {
+  const maxInputLength = resolveParserLimit(
+    options.maxInputLength,
+    DEFAULT_PARSE_SCRIPT_MAX_INPUT_LENGTH,
+    "maxInputLength",
+  );
+  const maxRecoveryAttempts = resolveParserLimit(
+    options.maxRecoveryAttempts,
+    DEFAULT_PARSE_SCRIPT_MAX_RECOVERY_ATTEMPTS,
+    "maxRecoveryAttempts",
+  );
   let script = content;
   if (script.startsWith("/")) {
     script = script.slice(1);
   }
+  assertParserInputLength(script, maxInputLength);
   if (!options.recoverSyntaxErrors) {
     return parse(script, { grammarSource: name });
   }
   let firstError: unknown;
-  for (let i = 0; i < 1000; i++) {
+  let recoveryAttempts = 0;
+  for (;;) {
     try {
       return parse(script, { grammarSource: name });
     } catch (e) {
@@ -28,16 +99,25 @@ const parseScript = (
       if (!(e instanceof PeggySyntaxError)) {
         throw e;
       }
+      if (recoveryAttempts >= maxRecoveryAttempts) {
+        throw new ParserRecoveryLimitError(maxRecoveryAttempts, e);
+      }
       console.info(e.format([{ source: name, text: script }]));
       const removed =
         script.slice(0, e.location.start.offset) +
         script.slice(e.location.start.offset + 1);
       if (script === removed) throw firstError;
+      recoveryAttempts++;
       script = removed;
     }
   }
-  throw firstError;
 };
 
-export { parseScript };
+export {
+  DEFAULT_PARSE_SCRIPT_MAX_INPUT_LENGTH,
+  DEFAULT_PARSE_SCRIPT_MAX_RECOVERY_ATTEMPTS,
+  ParserInputLimitError,
+  ParserRecoveryLimitError,
+  parseScript,
+};
 export type { ParseScriptOptions };

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -86,7 +86,7 @@ const parseScript = (
     script = script.slice(1);
   }
   assertParserInputLength(script, maxInputLength);
-  if (!options.recoverSyntaxErrors) {
+  if (!options.recoverSyntaxErrors || maxRecoveryAttempts === 0) {
     return parse(script, { grammarSource: name });
   }
   let firstError: unknown;


### PR DESCRIPTION
## Summary
- add parseScript input and recovery budget options with safe defaults
- reject oversized parser input before calling the generated parser
- cap opt-in syntax recovery attempts and surface a parser recovery limit error

## Validation
- npm test -- --run src/__tests__/parser.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run

## Review
- deep-review self-review completed
- independent subagent review completed: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds deterministic budget controls to the synchronous `parseScript` wrapper: a `maxInputLength` guard that rejects oversized input before the generated Peggy parser ever sees it, and a `maxRecoveryAttempts` cap that replaces the previous unbounded `for (let i = 0; i < 1000; i++)` recovery loop. Both limits ship with safe defaults (65 536 chars / 16 attempts) and are validated on entry via `resolveParserLimit`.

- `ParserInputLimitError` and `ParserRecoveryLimitError` are new structured error classes that carry the relevant limit as a typed field, and are exported through `NiwangoCore` for callers to narrow on.
- The `maxRecoveryAttempts: 0` case is correctly short-circuited to the non-recovery fast path (`!options.recoverSyntaxErrors || maxRecoveryAttempts === 0`), so it surfaces `PeggySyntaxError` directly — a previous thread concern that is now covered by a dedicated test.
- The input-length check is applied to the script **after** the leading `/` is stripped (matching the JSDoc description "passed to the generated parser"), which is consistent but worth being aware of when interpreting `ParserInputLimitError.inputLength` against the original `content` string.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes tighten existing behaviour without removing any previously public API, and the recovery loop that previously ran up to 1000 iterations is now properly bounded.

All three changed files are well-contained. The logic in the recovery loop terminates correctly under every reachable path (success, non-Peggy error, recovery limit, no-progress guard). Both new error classes expose structured fields, carry a cause, and are exported. The four new tests cover the boundaries that were previously untested. The downstream consumer in niwango.js wraps parseScript in a try/catch, so the new default maxInputLength doesn't break existing callers.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/parser/parse.ts | Adds maxInputLength guard (checked after leading-/ strip), bounded recovery loop with ParserRecoveryLimitError, and two new exported error classes; the maxRecoveryAttempts: 0 fast-path correctly re-uses the non-recovery branch and throws PeggySyntaxError directly |
| src/__tests__/parser.test.ts | Adds four new tests covering oversized input rejection, at-limit acceptance, recovery stopping at configured count, and the zero-budget fast-path; all new test names match the actual boundary semantics |
| src/main.ts | Re-exports ParserInputLimitError and ParserRecoveryLimitError as NiwangoCore static properties; no other changes |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([parseScript called]) --> B[resolveParserLimit\nmaxInputLength & maxRecoveryAttempts]
    B --> C{Invalid limit\nvalue?}
    C -->|Yes| D[throw RangeError]
    C -->|No| E[Strip leading /\nfrom script]
    E --> F{script.length\n> maxInputLength?}
    F -->|Yes| G[throw ParserInputLimitError]
    F -->|No| H{recoverSyntaxErrors\nor maxRecoveryAttempts > 0?}
    H -->|No recovery path| I[parse script directly]
    I -->|success| J([return AST])
    I -->|PeggySyntaxError| K([re-throw PeggySyntaxError])
    H -->|Recovery enabled| L[[Loop: recoveryAttempts = 0]]
    L --> M[parse script]
    M -->|success| J
    M -->|non-Peggy error| N([re-throw error])
    M -->|PeggySyntaxError| O{recoveryAttempts\n>= maxRecoveryAttempts?}
    O -->|Yes| P[throw ParserRecoveryLimitError\ncause = current error]
    O -->|No| Q[console.info the error\nremove char at error offset]
    Q --> R{script changed?}
    R -->|No progress| S([throw firstError])
    R -->|Yes| T[recoveryAttempts++\nscript = removed]
    T --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([parseScript called]) --> B[resolveParserLimit\nmaxInputLength & maxRecoveryAttempts]
    B --> C{Invalid limit\nvalue?}
    C -->|Yes| D[throw RangeError]
    C -->|No| E[Strip leading /\nfrom script]
    E --> F{script.length\n> maxInputLength?}
    F -->|Yes| G[throw ParserInputLimitError]
    F -->|No| H{recoverSyntaxErrors\nor maxRecoveryAttempts > 0?}
    H -->|No recovery path| I[parse script directly]
    I -->|success| J([return AST])
    I -->|PeggySyntaxError| K([re-throw PeggySyntaxError])
    H -->|Recovery enabled| L[[Loop: recoveryAttempts = 0]]
    L --> M[parse script]
    M -->|success| J
    M -->|non-Peggy error| N([re-throw error])
    M -->|PeggySyntaxError| O{recoveryAttempts\n>= maxRecoveryAttempts?}
    O -->|Yes| P[throw ParserRecoveryLimitError\ncause = current error]
    O -->|No| Q[console.info the error\nremove char at error offset]
    Q --> R{script changed?}
    R -->|No progress| S([throw firstError])
    R -->|Yes| T[recoveryAttempts++\nscript = removed]
    T --> M
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Expose parser budget errors"](https://github.com/xpadev-net/niwango-core.js/commit/f586ab21bdd493ba52a929769ecd7902ed18f768) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39462330)</sub>

<!-- /greptile_comment -->