### PR TITLE
Distinguish undefined scope slots

### DIFF
--- a/src/__tests__/bug.test.ts
+++ b/src/__tests__/bug.test.ts
@@ -14,3 +14,11 @@ test("bug:sm13570088", () => {
 test("bug:sm11605742", () => {
   expect(run(`return = "test";return`)).toBe("test");
 });
+
+test("local nil argument shadows outer slot", () => {
+  expect(run(`x="outer";def(read(x),x);read(nil)`)).toBeUndefined();
+});
+
+test("assignment targets local nil argument instead of outer slot", () => {
+  expect(run(`x="outer";def(write(x),(x="inner"));write(nil);x`)).toBe("outer");
+});

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -1,7 +1,7 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 import { execute, getName, setAssign } from "@/context";
 import typeGuard from "@/typeGuard";
-import { getOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
+import { hasOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
 /**
  * 変数に代入する関数
@@ -25,7 +25,7 @@ const assign = (
         return;
       }
       for (const scope of scopes) {
-        if (getOwnSlot(scope, key) !== undefined) {
+        if (hasOwnSlot(scope, key)) {
           setOwnSlot(scope, key, value);
           return;
         }

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -1,7 +1,12 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
 import { resultHook } from "@/context";
 import typeGuard from "@/typeGuard";
-import { getOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
+import {
+  getOwnSlot,
+  hasOwnSlot,
+  normalizeSlotKey,
+  setOwnSlot,
+} from "@/utils/slot";
 
 /**
  * 変数の参照を取得する関数
@@ -17,7 +22,7 @@ const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
         return undefined;
       }
       for (const scope of scopes) {
-        if (getOwnSlot(scope, key) !== undefined) {
+        if (hasOwnSlot(scope, key)) {
           return processResolveHook(scope, key);
         }
       }

--- a/src/utils/slot.ts
+++ b/src/utils/slot.ts
@@ -52,6 +52,14 @@ const getOwnSlot = (target: unknown, key: SlotKey | undefined): unknown => {
   return slotStore[key];
 };
 
+const hasOwnSlot = (target: unknown, key: SlotKey | undefined): boolean => {
+  const slotStore = getReadableSlotStore(target);
+  if (key === undefined || !slotStore) {
+    return false;
+  }
+  return Object.hasOwn(slotStore, key);
+};
+
 const setOwnSlot = (
   target: unknown,
   key: SlotKey | undefined,
@@ -67,5 +75,11 @@ const setOwnSlot = (
   return true;
 };
 
-export { createSlotStore, getOwnSlot, normalizeSlotKey, setOwnSlot };
+export {
+  createSlotStore,
+  getOwnSlot,
+  hasOwnSlot,
+  normalizeSlotKey,
+  setOwnSlot,
+};
 export type { SlotKey, SlotStore };


### PR DESCRIPTION
## Summary
- Add a slot-presence helper so scope lookup can distinguish own undefined/nil slots from absent slots
- Use presence checks for identifier lookup and reassignment target selection
- Add regressions for local nil argument lookup and reassignment shadowing an outer variable

## Validation
- npm test -- --run src/__tests__/bug.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- Deep-review self-review: no actionable findings
- Independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a scope-lookup bug where slots holding `undefined`/`nil` values were indistinguishable from absent slots. It introduces `hasOwnSlot` (backed by `Object.hasOwn`) and replaces the fragile `getOwnSlot(...) !== undefined` guards in both `resolve.ts` and `assign.ts`.

- **`src/utils/slot.ts`** — adds `hasOwnSlot`, which uses `Object.hasOwn` and correctly returns `false` for absent slots vs. `true` for slots present with a `nil`/`undefined` value, then exports it alongside the existing API.
- **`src/utils/resolve.ts` / `src/utils/assign.ts`** — swap the old value-comparison guard for `hasOwnSlot`, so identifier lookup and assignment targeting both stop at the first scope that *owns* the key, even when its current value is `nil`.
- **`src/__tests__/bug.test.ts`** — two regression tests covering the \"local nil argument read-through\" and \"nil-argument assignment shadow\" cases.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, well-tested, and closes a real shadowing bug without touching any public API surface.

The fix is a clean substitution of Object.hasOwn-backed presence check for a value-comparison that could not distinguish nil from absent. Both resolve.ts and assign.ts are updated consistently, the new hasOwnSlot mirrors getOwnSlot's existing guards exactly, createSlotStore already uses Object.create(null) so null-prototype safety is not a new concern, and two regression tests directly exercise the fixed paths. Related repos do not import these internal slot utilities, so there is no cross-repo breakage.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/slot.ts | Adds hasOwnSlot using Object.hasOwn — implementation is correct, null-prototype-safe, and consistent with getOwnSlot's existing guard. |
| src/utils/resolve.ts | Replaces getOwnSlot !== undefined with hasOwnSlot for scope-chain walk; fix is correct and processResolveHook still receives getOwnSlot result as expected. |
| src/utils/assign.ts | Replaces getOwnSlot !== undefined with hasOwnSlot for assignment target selection; getOwnSlot import correctly removed. Logic is sound. |
| src/__tests__/bug.test.ts | Two well-targeted regression tests for nil-shadowing and nil-assignment; cover both directions of the underlying scope-slot bug. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Identifier lookup / assign target] --> B[normalizeSlotKey]
    B --> C{key valid?}
    C -- No --> D[return / skip]
    C -- Yes --> E[iterate scopes]
    E --> F{hasOwnSlot scope key}
    F -- false\nslot absent --> G[next scope]
    G --> F
    F -- true\nslot present\neven if value is nil --> H[resolve: return value\nassign: set value in this scope]
    E -- no scope matched --> I[assign: create in scopes 0\nresolve: return undefined]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Identifier lookup / assign target] --> B[normalizeSlotKey]
    B --> C{key valid?}
    C -- No --> D[return / skip]
    C -- Yes --> E[iterate scopes]
    E --> F{hasOwnSlot scope key}
    F -- false\nslot absent --> G[next scope]
    G --> F
    F -- true\nslot present\neven if value is nil --> H[resolve: return value\nassign: set value in this scope]
    E -- no scope matched --> I[assign: create in scopes 0\nresolve: return undefined]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Distinguish undefined scope slots"](https://github.com/xpadev-net/niwango-core.js/commit/eb336036e73d8e7d68856e341700de042196f499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39463024)</sub>

<!-- /greptile_comment -->