### PR TITLE
Fix assignment target reference resolution

### DIFF
--- a/src/__tests__/bug.test.ts
+++ b/src/__tests__/bug.test.ts
@@ -1,5 +1,18 @@
 import { expect, test } from "vitest";
+import type { A_ANY } from "@/@types/ast";
+import { execute, prototypeScope } from "@/context";
 import { run } from "@/testUtils";
+
+const runAst = (body: A_ANY[], globalScope: Record<string, unknown>) => {
+  return execute(
+    {
+      type: "Program",
+      body,
+    },
+    [globalScope, {}, prototypeScope],
+    body,
+  );
+};
 
 test("bug:sm13570088", () => {
   expect(
@@ -44,4 +57,39 @@ test("compound member assignment reads defined function value once", () => {
       "obj={};calls=0;obj.def(value(),calls++;1);obj.value+=4;calls+':'+obj.value",
     ),
   ).toBe("1:5");
+});
+
+test("logical assignment short-circuits the right side", () => {
+  for (const [operator, value] of [
+    ["&&=", 0],
+    ["||=", 1],
+    ["??=", 1],
+  ] as const) {
+    const globalScope = { hit: 0, value };
+    expect(
+      runAst(
+        [
+          {
+            type: "AssignmentExpression",
+            operator,
+            left: {
+              type: "Identifier",
+              name: "value",
+            },
+            right: {
+              type: "UpdateExpression",
+              operator: "++",
+              argument: {
+                type: "Identifier",
+                name: "hit",
+              },
+              prefix: false,
+            },
+          },
+        ],
+        globalScope,
+      ),
+    ).toBe(value);
+    expect(globalScope).toEqual({ hit: 0, value });
+  }
 });

--- a/src/__tests__/bug.test.ts
+++ b/src/__tests__/bug.test.ts
@@ -22,3 +22,26 @@ test("local nil argument shadows outer slot", () => {
 test("assignment targets local nil argument instead of outer slot", () => {
   expect(run(`x="outer";def(write(x),(x="inner"));write(nil);x`)).toBe("outer");
 });
+
+test("plain member assignment does not execute the old defined function", () => {
+  expect(
+    run("obj={};hit=0;obj.def(method(),hit++);obj.method=1;hit+':'+obj.method"),
+  ).toBe("0:1");
+});
+
+test("computed assignment target key is evaluated once", () => {
+  expect(run("i=0;a=[0,0];a[i++]=5;i+':'+a[0]")).toBe("1:5");
+});
+
+test("compound and update member targets reuse one resolved reference", () => {
+  expect(run("i=0;a=[1];a[i++]+=4;i+':'+a[0]")).toBe("1:5");
+  expect(run("i=0;a=[1];a[i++]++;i+':'+a[0]")).toBe("1:2");
+});
+
+test("compound member assignment reads defined function value once", () => {
+  expect(
+    run(
+      "obj={};calls=0;obj.def(value(),calls++;1);obj.value+=4;calls+':'+obj.value",
+    ),
+  ).toBe("1:5");
+});

--- a/src/processors/AssignmentExpression.ts
+++ b/src/processors/AssignmentExpression.ts
@@ -51,9 +51,18 @@ const processAssignmentExpression = (
 ): unknown => {
   const reference = resolveReference(script.left, scopes, trace);
   const left = script.operator === "=" ? undefined : reference?.get();
-  const right = execute(script.right, scopes, trace);
   const processor = processors[script.operator];
   if (!processor) throw new NotImplementedError(script, scopes);
+  if (script.operator === "&&=" && !left) {
+    return left;
+  }
+  if (script.operator === "||=" && left) {
+    return left;
+  }
+  if (script.operator === "??=" && left !== null && left !== undefined) {
+    return left;
+  }
+  const right = execute(script.right, scopes, trace);
   const result = processor(left, right);
   reference?.set(result);
   return result;

--- a/src/processors/AssignmentExpression.ts
+++ b/src/processors/AssignmentExpression.ts
@@ -1,5 +1,5 @@
 import type { A_ANY, A_AssignmentExpression, T_scope } from "@/@types/ast";
-import { assign, execute } from "@/context";
+import { execute } from "@/context";
 import { NotImplementedError } from "@/errors/NotImplementedError";
 import {
   Addition,
@@ -15,6 +15,7 @@ import {
   Subtraction,
   UnsignedRightShift,
 } from "@/operators";
+import { resolveReference } from "@/utils/reference";
 
 /**
  * 演算子と処理の対応表
@@ -48,12 +49,13 @@ const processAssignmentExpression = (
   scopes: T_scope[],
   trace: A_ANY[],
 ): unknown => {
-  const left = execute(script.left, scopes, trace);
+  const reference = resolveReference(script.left, scopes, trace);
+  const left = script.operator === "=" ? undefined : reference?.get();
   const right = execute(script.right, scopes, trace);
   const processor = processors[script.operator];
   if (!processor) throw new NotImplementedError(script, scopes);
   const result = processor(left, right);
-  assign(script.left, result, scopes, trace);
+  reference?.set(result);
   return result;
 };
 

--- a/src/processors/UpdateExpression.ts
+++ b/src/processors/UpdateExpression.ts
@@ -1,7 +1,7 @@
 import type { A_ANY, A_UpdateExpression, T_scope } from "@/@types/ast";
-import { assign, execute } from "@/context";
 import { NotImplementedError } from "@/errors/NotImplementedError";
 import { Addition, Subtraction } from "@/operators";
+import { resolveReference } from "@/utils/reference";
 
 /**
  * 更新式を実行する
@@ -13,10 +13,11 @@ const processUpdateExpression = (
   scopes: T_scope[],
   trace: A_ANY[],
 ) => {
-  const value = execute(script.argument, scopes, trace);
+  const reference = resolveReference(script.argument, scopes, trace);
+  const value = reference?.get();
   if (script.operator === "--") {
     const result = Subtraction(value, 1);
-    assign(script.argument, result, scopes, trace);
+    reference?.set(result);
     if (script.prefix) {
       return result;
     } else {
@@ -24,7 +25,7 @@ const processUpdateExpression = (
     }
   } else if (script.operator === "++") {
     const result = Addition(value, 1);
-    assign(script.argument, result, scopes, trace);
+    reference?.set(result);
     if (script.prefix) {
       return result;
     } else {

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -1,7 +1,6 @@
 import type { A_ANY, T_scope } from "@/@types/ast";
-import { execute, getName, setAssign } from "@/context";
-import typeGuard from "@/typeGuard";
-import { hasOwnSlot, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
+import { setAssign } from "@/context";
+import { resolveReference } from "@/utils/reference";
 
 /**
  * 変数に代入する関数
@@ -19,39 +18,7 @@ const assign = (
     return;
   }
   try {
-    if (typeGuard.Identifier(target)) {
-      const key = normalizeSlotKey(target.name);
-      if (key === undefined) {
-        return;
-      }
-      for (const scope of scopes) {
-        if (hasOwnSlot(scope, key)) {
-          setOwnSlot(scope, key, value);
-          return;
-        }
-      }
-      if (scopes[0]) {
-        setOwnSlot(scopes[0], key, value);
-      }
-    } else if (typeGuard.MemberExpression(target)) {
-      const left = execute(target.object, scopes, trace);
-      if (!typeGuard.object(left)) {
-        console.error(
-          "[assign] left is not object",
-          target,
-          value,
-          scopes,
-          trace,
-        );
-        return;
-      }
-      const key = normalizeSlotKey(
-        target.computed
-          ? execute(target.property, scopes, trace)
-          : getName(target.property, scopes, trace),
-      );
-      setOwnSlot(left, key, value);
-    }
+    resolveReference(target, scopes, trace)?.set(value);
   } catch (e) {
     if (e instanceof Error) {
       console.error(

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -1,0 +1,82 @@
+import type { A_ANY, T_scope } from "@/@types/ast";
+import { execute, getName } from "@/context";
+import typeGuard from "@/typeGuard";
+import { getOwnSlot, hasOwnSlot, normalizeSlotKey, setOwnSlot } from "./slot";
+
+type Reference = {
+  get: () => unknown;
+  set: (value: unknown) => void;
+};
+
+const resolveReference = (
+  target: A_ANY,
+  scopes: T_scope[],
+  trace: A_ANY[],
+): Reference | undefined => {
+  if (scopes.length < 1) {
+    return undefined;
+  }
+  if (typeGuard.Identifier(target)) {
+    const key = normalizeSlotKey(target.name);
+    if (key === undefined) {
+      return undefined;
+    }
+    for (const scope of scopes) {
+      if (hasOwnSlot(scope, key)) {
+        return createSlotReference(scope, key, () =>
+          execute(target, scopes, trace),
+        );
+      }
+    }
+    return createSlotReference(scopes[0], key, () =>
+      execute(target, scopes, trace),
+    );
+  }
+  if (typeGuard.MemberExpression(target)) {
+    const left = execute(target.object, scopes, trace);
+    if (!typeGuard.object(left)) {
+      console.error("[reference] left is not object", target, scopes, trace);
+      return undefined;
+    }
+    const key = normalizeSlotKey(
+      target.computed
+        ? execute(target.property, scopes, trace)
+        : getName(target.property, scopes, trace),
+    );
+    return createSlotReference(left, key, () =>
+      execute(
+        {
+          type: "MemberExpression",
+          object: {
+            type: "Raw",
+            value: left,
+          },
+          property: {
+            type: "Raw",
+            value: key,
+          },
+          computed: false,
+        },
+        scopes,
+        trace,
+      ),
+    );
+  }
+  return undefined;
+};
+
+const createSlotReference = (
+  target: unknown,
+  key: string | number | undefined,
+  get: () => unknown = () => getOwnSlot(target, key),
+): Reference => {
+  return {
+    get,
+    set: (value: unknown) => {
+      setOwnSlot(target, key, value);
+    },
+  };
+};
+
+export { resolveReference };
+export type { Reference };


### PR DESCRIPTION
## Summary
- add a reference helper for assignment/update targets so target object/key resolution happens once
- skip old-value reads for plain `=` while preserving one old-value read for compound assignment and update expressions
- add regressions for defined-function overwrite, computed assignment keys, compound/update target reuse, and defined-function compound reads

## Validation
- npm test -- --run src/__tests__/bug.test.ts src/__tests__/Object.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run

## Review
- independent subagent review found compound/member defined-function read regression; fixed and covered by regression test

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `resolveReference` helper that captures an assignment/update target's object and key exactly once, then threads a typed `{get, set}` pair through `AssignmentExpression` and `UpdateExpression` processors. It also adds correct right-side short-circuit evaluation for `&&=`, `||=`, and `??=`, and suppresses the unnecessary old-value read for plain `=` assignment.

- **`src/utils/reference.ts`** (new): resolves an `Identifier` or `MemberExpression` target into a `Reference`; for `MemberExpression` the `get` path re-uses a synthetic AST so defined-function getters are invoked through the normal `execute` pipeline while `set` writes directly via `setOwnSlot`.
- **`AssignmentExpression.ts` / `UpdateExpression.ts`**: call `resolveReference` once, skipping double-evaluation of computed keys (e.g. `a[i++] += 4` now increments `i` only once) and unnecessary defined-function reads on plain `=`.
- **`bug.test.ts`**: five new regression tests covering all fixed cases, including a direct-AST test that validates the logical-assignment short-circuit without executing the right side.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused refactor of internal assignment mechanics with comprehensive regression coverage and no externally visible API changes.

All five changed files are internal processor/utility code. The new resolveReference helper correctly handles both Identifier and MemberExpression targets, the short-circuit logic for logical assignments matches JS semantics, and the regression tests exercise every fixed case. No correctness issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/reference.ts | New helper that resolves an assignment target (Identifier or MemberExpression) into a captured {get, set} pair, ensuring object/key evaluation happens exactly once. |
| src/processors/AssignmentExpression.ts | Refactored to use resolveReference; skips old-value read for plain `=`, implements correct right-side short-circuit for &&=, ||=, ??=, and reuses one resolved reference for both read and write. |
| src/processors/UpdateExpression.ts | Refactored to use resolveReference; the target is resolved once and the same reference is used for both the read and the write, fixing double-evaluation of computed keys. |
| src/utils/assign.ts | Internal logic removed in favour of delegating to resolveReference; error logging updated to a more informative format. No semantic change for callers. |
| src/__tests__/bug.test.ts | Added five regression tests covering defined-function plain assignment, computed-key single-evaluation, compound/update target reuse, defined-function compound reads, and logical-assignment short-circuit. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AE[AssignmentExpression / UpdateExpression] --> RR["resolveReference(target, scopes, trace)"]
    RR --> ID{Identifier?}
    RR --> ME{MemberExpression?}
    RR --> UN[return undefined]

    ID -->|find owning scope| SR1["createSlotReference(scope, key,\nget: () => execute(target, ...))\nset: setOwnSlot(scope, key, value)"]
    ME --> EO["execute(object) → left\nnormalizeSlotKey(property) → key"]
    EO --> SR2["createSlotReference(left, key,\nget: () => execute(synthetic MemberExpr)\nset: setOwnSlot(left, key, value))"]

    SR1 --> REF[Reference]
    SR2 --> REF

    REF --> AOP{operator?}
    AOP -->|"="| SKIP[skip get — left = undefined]
    AOP -->|compound += -= …| GET["reference.get() → old value"]
    AOP -->|"&&= / ||= / ??="| SC{short-circuit?}

    SC -->|yes| RET[return left, skip set]
    SC -->|no| GET

    SKIP --> EXEC["execute(right)"]
    GET --> EXEC
    EXEC --> PROC["processor(left, right) → result"]
    PROC --> SET["reference.set(result)"]
    SET --> RETURN[return result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    AE[AssignmentExpression / UpdateExpression] --> RR["resolveReference(target, scopes, trace)"]
    RR --> ID{Identifier?}
    RR --> ME{MemberExpression?}
    RR --> UN[return undefined]

    ID -->|find owning scope| SR1["createSlotReference(scope, key,\nget: () => execute(target, ...))\nset: setOwnSlot(scope, key, value)"]
    ME --> EO["execute(object) → left\nnormalizeSlotKey(property) → key"]
    EO --> SR2["createSlotReference(left, key,\nget: () => execute(synthetic MemberExpr)\nset: setOwnSlot(left, key, value))"]

    SR1 --> REF[Reference]
    SR2 --> REF

    REF --> AOP{operator?}
    AOP -->|"="| SKIP[skip get — left = undefined]
    AOP -->|compound += -= …| GET["reference.get() → old value"]
    AOP -->|"&&= / ||= / ??="| SC{short-circuit?}

    SC -->|yes| RET[return left, skip set]
    SC -->|no| GET

    SKIP --> EXEC["execute(right)"]
    GET --> EXEC
    EXEC --> PROC["processor(left, right) → result"]
    PROC --> SET["reference.set(result)"]
    SET --> RETURN[return result]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/75de507e6ca9db6bcdab7494d7884923187c2571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39464455)</sub>

<!-- /greptile_comment -->