### PR TITLE
Keep reset context references live

### DIFF
--- a/src/__tests__/ResetCore.test.ts
+++ b/src/__tests__/ResetCore.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { PrototypeFunction } from "@/@types/prototype";
+import NiwangoCore from "@/main";
+
+const executePublic = (niwango: string) => {
+  const ast = NiwangoCore.parseScript(niwango, "jest");
+  return NiwangoCore.execute(
+    ast,
+    [{}, {}, NiwangoCore.prototypeScope],
+    [ast],
+    {},
+  );
+};
+
+describe("resetCore public context", () => {
+  afterEach(() => {
+    NiwangoCore.resetCore();
+  });
+
+  test("keeps public prototypeScope connected to runtime resolution after reset", () => {
+    const publicScope = NiwangoCore.prototypeScope;
+
+    NiwangoCore.resetCore();
+    NiwangoCore.prototypeScope.Number.afterReset = (() => {
+      return "fresh";
+    }) as PrototypeFunction<number>;
+
+    expect(NiwangoCore.prototypeScope).toBe(publicScope);
+    expect(executePublic("(1).afterReset")).toBe("fresh");
+  });
+
+  test("keeps captured prototype categories live across repeated resets", () => {
+    const publicScope = NiwangoCore.prototypeScope;
+    const numberPrototype = NiwangoCore.prototypeScope.Number;
+
+    NiwangoCore.resetCore();
+    NiwangoCore.resetCore();
+    numberPrototype.afterRepeatedReset = (() => {
+      return "still current";
+    }) as PrototypeFunction<number>;
+
+    expect(NiwangoCore.prototypeScope).toBe(publicScope);
+    expect(NiwangoCore.prototypeScope.Number).toBe(numberPrototype);
+    expect(executePublic("(1).afterRepeatedReset")).toBe("still current");
+  });
+
+  test("preserves built-in prototypes after reset", () => {
+    NiwangoCore.resetCore();
+
+    expect(executePublic("[1,2,3].sum")).toBe(6);
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -37,11 +37,40 @@ const setResolvePrototype = (val: ResolvePrototype) => {
   resolvePrototype = val;
 };
 
-let prototypeScope: {
-  [key in "Array" | "Bool" | "Number" | "Object" | "String" | "Value"]: {
+type PrototypeScopeKey =
+  | "Array"
+  | "Bool"
+  | "Number"
+  | "Object"
+  | "String"
+  | "Value";
+
+type PrototypeScope = {
+  [key in PrototypeScopeKey]: {
     [key: string]: unknown;
   };
-} = {
+};
+
+const prototypeScopeKeys: PrototypeScopeKey[] = [
+  "Array",
+  "Bool",
+  "Number",
+  "Object",
+  "String",
+  "Value",
+];
+
+const clearMutableObject = (object: { [key: string]: unknown }) => {
+  for (const key of Object.keys(object)) {
+    delete object[key];
+  }
+};
+
+const isPrototypeScopeKey = (key: string): key is PrototypeScopeKey => {
+  return prototypeScopeKeys.includes(key as PrototypeScopeKey);
+};
+
+const prototypeScope: PrototypeScope = {
   Array: {},
   Bool: {},
   Number: {},
@@ -51,20 +80,21 @@ let prototypeScope: {
 };
 
 const initPrototypeScope = () => {
-  prototypeScope = {
-    Array: {},
-    Bool: {},
-    Number: {},
-    Object: {},
-    String: {},
-    Value: {},
-  };
+  const prototypeScopeRecord = prototypeScope as Record<string, unknown>;
+  for (const key of Object.keys(prototypeScopeRecord)) {
+    if (!isPrototypeScopeKey(key)) {
+      delete prototypeScopeRecord[key];
+    }
+  }
+  for (const key of prototypeScopeKeys) {
+    clearMutableObject(prototypeScope[key]);
+  }
 };
 
-let definedFunctions: { [key: string]: IrFunction } = {};
+const definedFunctions: { [key: string]: IrFunction } = {};
 
 const initDefinedFunctions = () => {
-  definedFunctions = {};
+  clearMutableObject(definedFunctions);
 };
 
 const appendDefinedFunctions = (name: string, func: IrFunction) => {
@@ -77,14 +107,14 @@ const setIsWide = (val: boolean) => {
   isWide = val;
 };
 
-let resultHook: ((input: unknown) => unknown)[] = [];
+const resultHook: ((input: unknown) => unknown)[] = [];
 
 const appendResultHook = (func: (input: unknown) => unknown) => {
   resultHook.push(func);
 };
 
 const initResultHook = () => {
-  resultHook = [];
+  resultHook.length = 0;
 };
 
 export {


### PR DESCRIPTION
## Summary
- Reset mutable context containers in place so public static references stay connected after resetCore()
- Preserve prototype category object identity across repeated resets while clearing custom prototype slots
- Add resetCore regression coverage for public prototypeScope and built-in prototype behavior

## Validation
- npm test -- --run src/__tests__/ResetCore.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- deep-review self-review: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a latent reference-staleness bug where `resetCore()` replaced the `prototypeScope`, `definedFunctions`, and `resultHook` objects with fresh ones, silently disconnecting any caller that had captured those references (most critically `NiwangoCore.prototypeScope`, which is assigned once at class-definition time in `main.ts`). The fix switches all three containers to `const` and clears them in place, while a new two-pass `initPrototypeScope` also evicts any extra top-level keys that users may have added at runtime outside TypeScript's type system.

- **`context.ts`**: `prototypeScope`, `definedFunctions`, and `resultHook` are now `const`; their `init*` functions clear them in place (`clearMutableObject`, `length = 0`) instead of reassigning.
- **`ResetCore.test.ts`**: Three new regression tests verify that the public `prototypeScope` and its inner category objects remain the same reference after one and two consecutive resets, and that built-in prototype methods still resolve correctly after reset.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted in-place-clear refactor with no external API surface changes and good regression coverage.

The implementation is mechanically correct: Object.keys returns a snapshot so iterating while deleting is safe, clearMutableObject only touches own enumerable properties, resultHook.length = 0 is idiomatic, and the two-pass initPrototypeScope correctly handles both the top-level unknown-key case and inner category clearing. Built-in prototypes live in separate constant objects that resetCore never touches. The only untested path is definedFunctions and resultHook reference identity, which is inconsequential since neither is publicly exposed on NiwangoCore.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/context.ts | Converts mutable container variables to const and clears them in place; adds well-scoped helper types and functions; no logic errors detected. |
| src/__tests__/ResetCore.test.ts | New regression suite covering top-level scope identity, inner category object identity across repeated resets, and built-in prototype availability post-reset. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep reset context references live"](https://github.com/xpadev-net/niwango-core.js/commit/39df49be2c8e3787e17fa2e27e7a7dc257390b86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39465381)</sub>

<!-- /greptile_comment -->