### PR TITLE
Align Array prototype JS compatibility

### DIFF
--- a/src/__tests__/Array.test.ts
+++ b/src/__tests__/Array.test.ts
@@ -25,6 +25,7 @@ describe("Array.prototype", () => {
   });
 
   test("join", () => {
+    expect(run(`array=['A','B','C'];array.join()`)).toBe("A,B,C");
     expect(run(`array=['A','B','C'];array.join('-')`)).toBe("A-B-C");
     expect(run(`array=[1,2,3];array.join('')`)).toBe("123");
   });
@@ -45,6 +46,11 @@ describe("Array.prototype", () => {
 
   test("push", () => {
     expect(run(`array = ["A","B","C"];array.push("D")`)).toBe(4);
+    expect(
+      run(
+        `i = 0;array = ["A"];result = array.push(i += 1,i += 1);result + ":" + array.join("-")`,
+      ),
+    ).toBe("3:A-1-2");
     expect(
       run(
         `array = ["A","B","C"];array.push("D");array.size + ":" + array[array.size-1]`,
@@ -73,6 +79,11 @@ describe("Array.prototype", () => {
 
   test("unshift", () => {
     expect(run(`array = ["A","B","C"];array.unshift("D")`)).toBe(4);
+    expect(
+      run(
+        `i = 0;array = ["A"];result = array.unshift(i += 1,i += 1);result + ":" + array.join("-")`,
+      ),
+    ).toBe("3:1-2-A");
     expect(
       run(
         `array = ["A","B","C"];array.unshift("D");array.size + ":" + array[0]`,

--- a/src/prototype/Array/join.ts
+++ b/src/prototype/Array/join.ts
@@ -9,11 +9,13 @@ const processJoin: PrototypeArrayFunction = (
   object,
   trace: A_ANY[],
 ) => {
-  const separator = execute(script.arguments[0], scopes, trace);
-  if (typeof separator !== "undefined") {
-    return object.join(format(separator, "string"));
+  if (script.arguments.length > 0) {
+    const separator = execute(script.arguments[0], scopes, trace);
+    if (typeof separator !== "undefined") {
+      return object.join(format(separator, "string"));
+    }
   }
-  return object.join("");
+  return object.join(",");
 };
 
 export { processJoin };

--- a/src/prototype/Array/push.ts
+++ b/src/prototype/Array/push.ts
@@ -8,8 +8,10 @@ const processPush: PrototypeArrayFunction = (
   object,
   trace: A_ANY[],
 ) => {
-  const value = execute(script.arguments[0], scopes, trace);
-  return object.push(value);
+  const values = script.arguments.map((argument) =>
+    execute(argument, scopes, trace),
+  );
+  return object.push(...values);
 };
 
 export { processPush };

--- a/src/prototype/Array/unshift.ts
+++ b/src/prototype/Array/unshift.ts
@@ -8,8 +8,10 @@ const processUnshift: PrototypeArrayFunction = (
   object,
   trace: A_ANY[],
 ) => {
-  const value = execute(script.arguments[0], scopes, trace);
-  return object.unshift(value);
+  const values = script.arguments.map((argument) =>
+    execute(argument, scopes, trace),
+  );
+  return object.unshift(...values);
 };
 
 export { processUnshift };


### PR DESCRIPTION
## Summary
- evaluate and append/prepend all Array push/unshift arguments in order
- default Array join() to comma while preserving explicit separators
- add focused Array prototype regressions for multi-arg mutation and join defaults

## Validation
- npm test -- --run src/__tests__/Array.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- deep-review self-review: no actionable findings
- independent subagent final review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three JS-compatibility gaps in the Array prototype implementation: `join()` now defaults to a comma separator (matching the JS spec, previously used empty string), and both `push()` and `unshift()` now accept and correctly process multiple arguments in left-to-right order.

- **`join.ts`**: Added an `arguments.length` guard so no-arg calls use `","`, and argument-provided-but-undefined calls also fall through to `","` — both consistent with the JS spec.
- **`push.ts` / `unshift.ts`**: Replaced single-argument evaluation with `arguments.map(execute)` + spread, ensuring all values are evaluated in order before mutation.
- **`Array.test.ts`**: Added targeted regression cases for no-arg `join()`, and side-effecting multi-arg `push` and `unshift` to lock in evaluation order and result.
</details>

<h3>Confidence Score: 5/5</h3>

All three changes are narrowly scoped corrections to bring niwango-core's Array prototype in line with standard JS behavior, each backed by a new regression test.

The changes are small, well-contained, and each accompanied by a focused test that pins the previously broken behavior. No related-repo consumers were found that depend on the old (incorrect) empty-string join default or single-argument push/unshift semantics.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/prototype/Array/join.ts | Fixes join() default separator from empty string to comma (JS spec) and adds an argument-length guard before evaluating the separator expression. |
| src/prototype/Array/push.ts | Replaces single-argument push with a map-then-spread pattern so all arguments are evaluated in order and appended together. |
| src/prototype/Array/unshift.ts | Mirrors the push fix for unshift: all arguments evaluated left-to-right via map then prepended together via spread. |
| src/__tests__/Array.test.ts | Adds regression tests for no-arg join(), multi-arg push with side-effecting arguments, and multi-arg unshift with side-effecting arguments. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["array.join(arg?)"] --> B{arguments.length > 0?}
    B -- No --> C["object.join(',')"]
    B -- Yes --> D["execute(arguments[0])"]
    D --> E{separator === undefined?}
    E -- Yes --> C
    E -- No --> F["object.join(format(separator, 'string'))"]

    G["array.push(a, b, ...)"] --> H["arguments.map(execute)"]
    H --> I["object.push(...values)"]

    J["array.unshift(a, b, ...)"] --> K["arguments.map(execute)"]
    K --> L["object.unshift(...values)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["array.join(arg?)"] --> B{arguments.length > 0?}
    B -- No --> C["object.join(',')"]
    B -- Yes --> D["execute(arguments[0])"]
    D --> E{separator === undefined?}
    E -- Yes --> C
    E -- No --> F["object.join(format(separator, 'string'))"]

    G["array.push(a, b, ...)"] --> H["arguments.map(execute)"]
    H --> I["object.push(...values)"]

    J["array.unshift(a, b, ...)"] --> K["arguments.map(execute)"]
    K --> L["object.unshift(...values)"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/a874f4787072c243e80f38b45858cd2b7fbbc1ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39466669)</sub>

<!-- /greptile_comment -->