### PR TITLE
Fix hex string subtraction conversion

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -11,6 +11,14 @@ test("sample from wiki", () => {
   expect(run("a = 0x2525; a")).toBe(9509);
 });
 
+test("string subtraction numeric conversion", () => {
+  expect(run(`"2525" - 0`)).toBe(2525);
+  expect(run(`"0x10" - 0`)).toBe(16);
+  expect(run(`"0xA" - 0`)).toBe(10);
+  expect(run(`"0xa" - 0`)).toBe(10);
+  expect(run(`"0xG" - 0`)).toBe(0);
+});
+
 test("variable declaration", () => {
   expect(run("i=0;i")).toBe(0);
 });

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -43,12 +43,13 @@ const assertStringRepeatResourceLimit = (value: string, repeat: number) => {
  */
 const Subtraction = (left: unknown, right: unknown) => {
   const rightNum = format(right, "number");
-  if (
-    rightNum === 0 &&
-    typeof left === "string" &&
-    left.match(/^(0|0x)?[0-9]+(\.[0-9]+)?$/)
-  ) {
-    return Number(left);
+  if (rightNum === 0 && typeof left === "string") {
+    if (left.match(/^0x[0-9a-f]+$/i)) {
+      return parseInt(left.slice(2), 16);
+    }
+    if (left.match(/^(0|0x)?[0-9]+(\.[0-9]+)?$/)) {
+      return Number(left);
+    }
   }
   return format(left, "number") - rightNum;
 };


### PR DESCRIPTION
## Summary
- Parse subtraction string operands matching /^0x[0-9a-f]+$/i as base-16 when subtracting zero.
- Keep invalid hex-looking strings on the existing String.toASNumber fallback.
- Add runtime regressions for lowercase/uppercase hex, invalid hex fallback, and decimal string conversion.

## Validation
- pnpm vitest run src/__tests__/niwango.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- deep-review self-pass: no actionable findings.
- independent subagent review (Hooke): no actionable findings; verified focused niwango test passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes hex string-to-number conversion in the `Subtraction` operator when the right operand is zero. The old regex (`/^(0|0x)?[0-9]+(\.[0-9]+)?$/`) accepted only decimal digits after an optional `0x` prefix, so `"0xA" - 0` incorrectly returned `0`; the new code first checks for a proper hex string with `/^0x[0-9a-f]+$/i` and calls `parseInt(left.slice(2), 16)`.

- **`src/operators.ts`**: Splits the single early-return branch into two: one for valid hex strings (parsed with `parseInt` base 16) and one for the existing numeric-string regex, preserving the `toASNumber` fallback (`0`) for invalid inputs like `"0xG"`.
- **`src/__tests__/niwango.test.ts`**: Adds five regression cases covering decimal strings, lowercase/uppercase hex, and invalid hex-looking strings (`"0xG"`).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested fix to a narrowly scoped conversion path.

The logic restructuring is correct: the hex regex is checked first and is mutually exclusive from the decimal-string regex for any valid hex input, so no overlap or regression is introduced. The toASNumber fallback for unrecognized strings (always 0) is preserved. All five new test cases exercise the meaningful branches.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/operators.ts | Correctly splits hex parsing from decimal-string parsing in Subtraction; logic is sound and ordering ensures no overlap issues. |
| src/__tests__/niwango.test.ts | Adds regression tests for the five key cases; missing coverage for edge inputs like empty '0x', negative-prefixed hex strings, and non-zero right operands with hex-looking left operands. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Subtraction left right] --> B[rightNum = format right number]
    B --> C{rightNum is 0 AND left is string?}
    C -- No --> G[format left number minus rightNum]
    C -- Yes --> D{left matches hex regex?}
    D -- Yes --> E["parseInt base-16: '0xA' → 10"]
    D -- No --> F{left matches decimal regex?}
    F -- Yes --> H["Number(left): '2525' → 2525"]
    F -- No --> I["toASNumber fallback: '0xG' → 0"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Subtraction left right] --> B[rightNum = format right number]
    B --> C{rightNum is 0 AND left is string?}
    C -- No --> G[format left number minus rightNum]
    C -- Yes --> D{left matches hex regex?}
    D -- Yes --> E["parseInt base-16: '0xA' → 10"]
    D -- No --> F{left matches decimal regex?}
    F -- Yes --> H["Number(left): '2525' → 2525"]
    F -- No --> I["toASNumber fallback: '0xG' → 0"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix hex string subtraction conversion"](https://github.com/xpadev-net/niwango-core.js/commit/9f31b30e843a44943575d027d8860b69913b3afa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39487059)</sub>

<!-- /greptile_comment -->