### PR TITLE
Fix Value hashCode and slot iteration

### DIFF
--- a/src/__tests__/Object.test.ts
+++ b/src/__tests__/Object.test.ts
@@ -51,6 +51,34 @@ describe("Object.prototype", () => {
     expect(run("hoge={test:256};hoge.test")).toBe(256);
   });
 
+  test("forEachSlot iterates object slots with key and value", () => {
+    expect(
+      run(
+        `result="";hoge={a:1,b:2};hoge.forEachSlot(\\(result+=@0+":"+@1+";"));result`,
+      ),
+    ).toBe("a:1;b:2;");
+  });
+
+  test("forEachSlot iterates array slots with numeric key and value", () => {
+    expect(
+      run(
+        `result="";hoge=["A","B"];hoge.forEachSlot(\\(result+=@0+":"+@1+";"));result`,
+      ),
+    ).toBe("0:A;1:B;");
+  });
+
+  test("forEachSlot preserves named array slot keys", () => {
+    expect(
+      run(
+        `result="";hoge=[];hoge.setSlot("name","N");hoge.forEachSlot(\\(result+=@0+":"+@1+";"));result`,
+      ),
+    ).toBe("name:N;");
+  });
+
+  test("forEachSlot leaves empty object untouched", () => {
+    expect(run(`i=0;hoge={};hoge.forEachSlot(\\(i++));i`)).toBe(0);
+  });
+
   test("clone", () => {
     expect(
       run("hoge={test:256};huga=hoge.clone;huga.test=1024;hoge.test"),

--- a/src/__tests__/Value.test.ts
+++ b/src/__tests__/Value.test.ts
@@ -25,6 +25,14 @@ describe("Value.prototype", () => {
     expect(run(`10.equals(10)`)).toBe(true);
     expect(run(`10.equals(5)`)).toBe(false);
   });
+  test("fallback hashCode", () => {
+    expect(run(`({}).hashCode()`)).toBe(0);
+    expect(run(`true.hashCode`)).toBe(0);
+  });
+  test("legacy hashCore alias", () => {
+    expect(run(`({}).hashCore()`)).toBe(0);
+    expect(run(`false.hashCore`)).toBe(0);
+  });
   test("minus", () => {
     expect(run(`10.minus`)).toBe(-10);
     expect(run(`-5.minus`)).toBe(5);

--- a/src/prototype/Value/forEachSlot.ts
+++ b/src/prototype/Value/forEachSlot.ts
@@ -1,8 +1,44 @@
-import { NotImplementedError } from "@/errors/NotImplementedError";
+import type { A_ANY } from "@/@types";
+import { execute } from "@/context";
 import type { PrototypeValueFunction } from "@/prototype/Value/index";
+import typeGuard from "@/typeGuard";
+import { createSlotStore, normalizeSlotKey, setOwnSlot } from "@/utils/slot";
 
-const processForEachSlot: PrototypeValueFunction = (script, scopes) => {
-  throw new NotImplementedError(script, scopes);
+const processForEachSlot: PrototypeValueFunction = (
+  script,
+  scopes,
+  object,
+  trace: A_ANY[],
+) => {
+  const processor = script.arguments[0];
+  if (
+    !typeGuard.LambdaExpression(processor) ||
+    typeof object !== "object" ||
+    object === null
+  ) {
+    return;
+  }
+
+  let result: unknown;
+  const slots = object as Record<string, unknown>;
+  for (const key of Object.keys(object)) {
+    const slotKey = normalizeSlotKey(
+      Array.isArray(object) && isArrayIndex(key) ? Number(key) : key,
+    );
+    if (slotKey === undefined) {
+      continue;
+    }
+    const slotScope = createSlotStore();
+    setOwnSlot(slotScope, "@0", slotKey);
+    setOwnSlot(slotScope, "@1", slots[key]);
+    result = execute(processor.body, [slotScope, ...scopes], trace);
+  }
+  return result;
+};
+
+const isArrayIndex = (key: string): boolean => {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && String(index) === key;
 };
 
 export { processForEachSlot };

--- a/src/prototype/Value/index.ts
+++ b/src/prototype/Value/index.ts
@@ -36,6 +36,7 @@ const prototypeValueFunctions: PrototypeFunctions<unknown> = {
   hasSlot: processHasSlot,
   equals: processEquals,
   compare: processCompare,
+  hashCode: processHashCode,
   hashCore: processHashCode,
   forEachSlot: processForEachSlot,
   call: processCall,


### PR DESCRIPTION
## Summary
- register the fallback Value hashCode method under hashCode while retaining the legacy hashCore alias
- implement narrow Value.forEachSlot iteration for object and array own slots with @0 as key and @1 as value
- add focused regressions for hashCode/hashCore and object, array, named array slot, and empty object forEachSlot behavior

## Validation
- npm test -- --run src/__tests__/Value.test.ts src/__tests__/Object.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run

## Review
- Deep self-review completed locally; no remaining actionable findings.
- Independent parent-side replacement review agent 019ef85b-8a73-7cc2-a5b8-68dc4a5664b5 (Singer): No actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two `Value.prototype` gaps: it registers `hashCode` as its own entry in the dispatch table (was previously only reachable through the `hashCore` alias), and it replaces the `forEachSlot` `NotImplementedError` stub with a working implementation that iterates own enumerable slots of objects and arrays, binding `@0` as the key and `@1` as the value inside each lambda invocation.

- **`hashCode` registration** (`src/prototype/Value/index.ts`): a one-liner addition above the existing `hashCore` alias; both now point to `processHashCode`.
- **`forEachSlot` implementation** (`src/prototype/Value/forEachSlot.ts`): uses `Object.keys` for own-slot iteration, converts numeric array indices to JS numbers for the key binding, creates an isolated `null`-prototype slot scope per iteration via `createSlotStore`, and returns the last lambda result — consistent with `processWalk`.
- **Tests** (`Value.test.ts`, `Object.test.ts`): four new `forEachSlot` cases (plain object, array, named array slot, empty object) and two `hashCode`/`hashCore` cases.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrow, well-tested corrections to previously missing or mis-keyed prototype dispatch entries.

The `hashCode` fix is a one-liner that simply adds the canonical name alongside its existing alias. The `forEachSlot` implementation follows the same pattern as `processWalk`, uses the existing safe slot utilities (`createSlotStore`, `normalizeSlotKey`, `setOwnSlot`), and guards correctly against primitives and missing lambda arguments. Four targeted regression tests cover the key edge cases (plain object, array, named array slot, empty object).

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/prototype/Value/forEachSlot.ts | Replaces the stub NotImplementedError with a full implementation that iterates own enumerable slots of objects and arrays, binding @0/@1 per iteration via createSlotStore. |
| src/prototype/Value/index.ts | Registers hashCode as a first-class entry alongside the existing hashCore alias; no logic changes. |
| src/__tests__/Object.test.ts | Adds four forEachSlot regression tests: plain object, array, named array slot, and empty object. |
| src/__tests__/Value.test.ts | Adds two regression tests covering hashCode and hashCore fallback returning 0. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processForEachSlot called] --> B{processor is LambdaExpression AND object is non-null object?}
    B -- No --> C[return undefined]
    B -- Yes --> D[Iterate Object.keys of object]
    D --> E{More keys?}
    E -- No --> F[return last result]
    E -- Yes --> G[Get next key]
    G --> H{Array.isArray AND isArrayIndex?}
    H -- Yes --> I[slotKey = Number key]
    H -- No --> J[slotKey = string key]
    I --> K[normalizeSlotKey]
    J --> K
    K --> L{slotKey undefined?}
    L -- Yes --> E
    L -- No --> N[createSlotStore]
    N --> O[setOwnSlot: @0 = slotKey, @1 = value]
    O --> P[execute lambda body with slotScope + scopes]
    P --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processForEachSlot called] --> B{processor is LambdaExpression AND object is non-null object?}
    B -- No --> C[return undefined]
    B -- Yes --> D[Iterate Object.keys of object]
    D --> E{More keys?}
    E -- No --> F[return last result]
    E -- Yes --> G[Get next key]
    G --> H{Array.isArray AND isArrayIndex?}
    H -- Yes --> I[slotKey = Number key]
    H -- No --> J[slotKey = string key]
    I --> K[normalizeSlotKey]
    J --> K
    K --> L{slotKey undefined?}
    L -- Yes --> E
    L -- No --> N[createSlotStore]
    N --> O[setOwnSlot: @0 = slotKey, @1 = value]
    O --> P[execute lambda body with slotScope + scopes]
    P --> E
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/6731e4217571a2226b51db76c6960697f8220ade) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39487630)</sub>

<!-- /greptile_comment -->