### PR TITLE
Fix variable declaration list continuation

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -21,6 +21,9 @@ test("string subtraction numeric conversion", () => {
 
 test("variable declaration", () => {
   expect(run("i=0;i")).toBe(0);
+  expect(run("i=1;i")).toBe(1);
+  expect(run("a,b:=2;b")).toBe(2);
+  expect(run("a,b:=2,c:=3;c")).toBe(3);
 });
 test("calculation declaration", () => {
   expect(run("1+1")).toBe(2);

--- a/src/processors/VariableDeclaration.ts
+++ b/src/processors/VariableDeclaration.ts
@@ -15,7 +15,7 @@ const processVariableDeclaration = (
   let lastItem: unknown;
   for (const item of script.declarations) {
     if (item.init === null) {
-      return execute(item.id, scopes, trace);
+      lastItem = execute(item.id, scopes, trace);
     } else {
       if (scopes[0]) {
         lastItem = scopes[0][getName(item.id, scopes, trace) as string] =


### PR DESCRIPTION
## Summary
- Continue processing variable declaration lists after an uninitialized declarator
- Preserve bare identifier/single declaration behavior by keeping the last evaluated declarator result
- Add regressions for later initialized declarators after uninitialized entries

## Validation
- npm test -- --run src/__tests__/niwango.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- Self-review with deep-review checklist: no actionable findings
- Independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a premature `return` in `processVariableDeclaration` that caused the loop over a declaration list to exit early when an uninitialized declarator was encountered, preventing any subsequent declarators from being evaluated or assigned.

- **`VariableDeclaration.ts`**: Changes `return execute(item.id, …)` to `lastItem = execute(item.id, …)` so the loop continues processing all entries in the declaration list before returning the last-evaluated value.
- **`niwango.test.ts`**: Adds three regression cases covering single-value assignment (`i=1`), a later-initialized declarator after an uninitialized one (`a,b:=2`), and multiple initialized declarators following an uninitialized entry (`a,b:=2,c:=3`).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal and directly corrects well-understood incorrect behavior.

The fix is a single-line change (return → lastItem =) that aligns the uninitialized-declarator branch with the initialized branch. The loop already accumulated results in lastItem for the initialized path, so the uninitialized path now follows the same pattern. Three targeted regression tests confirm the previously broken cases now pass. No shared interfaces or cross-repo contracts are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/processors/VariableDeclaration.ts | Single-line fix: replaces early `return` with `lastItem =` assignment so uninitialized declarators no longer abort the declaration-list loop. |
| src/__tests__/niwango.test.ts | Adds three targeted regression tests that cover the fixed bug: basic assignment, uninitialized-then-initialized, and multiple initialized declarators after an uninitialized entry. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processVariableDeclaration] --> B[for each item in declarations]
    B --> C{item.init is null?}
    C -->|Yes - uninitialized| D["lastItem = execute(item.id, ...)"]
    C -->|No - initialized| E{scopes at 0 exists?}
    E -->|Yes| F["lastItem = scopes[0][name] = execute(item.init, ...)"]
    E -->|No| B
    D --> B
    F --> B
    B -->|loop done| G[return lastItem]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processVariableDeclaration] --> B[for each item in declarations]
    B --> C{item.init is null?}
    C -->|Yes - uninitialized| D["lastItem = execute(item.id, ...)"]
    C -->|No - initialized| E{scopes at 0 exists?}
    E -->|Yes| F["lastItem = scopes[0][name] = execute(item.init, ...)"]
    E -->|No| B
    D --> B
    F --> B
    B -->|loop done| G[return lastItem]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niwango-core.js/commit/b3b6f90c162e1a55808cc47a3c1da2ca0db82dbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39488231)</sub>

<!-- /greptile_comment -->