### PR TITLE
Align AST type declarations with parser shape

### DIFF
--- a/src/@types/ast.d.ts
+++ b/src/@types/ast.d.ts
@@ -11,6 +11,7 @@ export type A_ANY =
   | A_ConditionalExpression
   | A_IfStatement
   | A_Lambda
+  | A_ParsedLambdaExpression
   | A_LambdaExpression
   | A_MemberExpression
   | A_LogicalExpression
@@ -30,7 +31,7 @@ export type A_Identifier = {
 };
 export type A_Literal = {
   type: "Literal";
-  value: null | boolean | number | string;
+  value: undefined | null | boolean | number | string;
 };
 export type A_ExpressionStatement = {
   type: "ExpressionStatement";
@@ -61,7 +62,7 @@ export type AssignmentExpressionOperator =
   | "??=";
 export type A_ArrayExpression = {
   type: "ArrayExpression";
-  elements: A_ANY[];
+  elements: (A_ANY | null)[];
 };
 export type A_ArrowFunctionExpression = {
   type: "ArrowFunctionExpression";
@@ -123,6 +124,11 @@ export type A_LambdaExpression = {
   type: "LambdaExpression";
   body: A_BlockStatement;
   scopes: T_scope[];
+};
+export type A_ParsedLambdaExpression = {
+  type: "LambdaExpression";
+  body: A_BlockStatement;
+  scopes?: undefined;
 };
 export type A_MemberExpression = {
   type: "MemberExpression";

--- a/src/__tests__/astTypes.test.ts
+++ b/src/__tests__/astTypes.test.ts
@@ -96,4 +96,17 @@ describe("parser AST shapes covered by declarations", () => {
       expect.objectContaining({ type: "Literal", value: 2 }),
     ]);
   });
+
+  test("parses conditional expressions as general AST nodes", () => {
+    const ast = parse("true ? 1 : 2") as A_Program;
+    const statement = ast.body[0];
+
+    expect(statement?.type).toBe("ExpressionStatement");
+    if (statement?.type !== "ExpressionStatement") {
+      throw new Error("expected expression statement");
+    }
+
+    expect(statement.expression.type).toBe("ConditionalExpression");
+    expect(asAst(statement.expression)).toBe(statement.expression);
+  });
 });

--- a/src/__tests__/astTypes.test.ts
+++ b/src/__tests__/astTypes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import type {
+  A_ANY,
+  A_ArrayExpression,
+  A_ConditionalExpression,
+  A_LambdaExpression,
+  A_Literal,
+  A_ParsedLambdaExpression,
+  A_Program,
+} from "@/@types/ast";
+import { parse } from "@/parser/parser";
+
+const asAst = (node: A_ANY) => node;
+
+describe("AST type declarations", () => {
+  test("allow runtime nil literals to carry undefined", () => {
+    const literal: A_Literal = { type: "Literal", value: undefined };
+
+    expect(literal.value).toBeUndefined();
+  });
+
+  test("allow parsed lambdas before runtime scopes are attached", () => {
+    const parsedLambda: A_ParsedLambdaExpression = {
+      type: "LambdaExpression",
+      body: { type: "BlockStatement", body: [] },
+    };
+    const runtimeLambda: A_LambdaExpression = {
+      ...parsedLambda,
+      scopes: [],
+    };
+
+    expect(parsedLambda.scopes).toBeUndefined();
+    expect(runtimeLambda.scopes).toEqual([]);
+  });
+
+  test("keeps conditional expressions in the general AST union", () => {
+    const conditional: A_ConditionalExpression = {
+      type: "ConditionalExpression",
+      test: { type: "Literal", value: true },
+      consequent: { type: "Literal", value: 1 },
+      alternate: { type: "Literal", value: 2 },
+    };
+
+    expect(asAst(conditional)).toBe(conditional);
+  });
+
+  test("allows parser-emitted null elements for array elision", () => {
+    const array: A_ArrayExpression = {
+      type: "ArrayExpression",
+      elements: [null, { type: "Literal", value: 1 }],
+    };
+
+    expect(array.elements[0]).toBeNull();
+  });
+});
+
+describe("parser AST shapes covered by declarations", () => {
+  test("parses lambdas without runtime-only scopes", () => {
+    const ast = parse("x=\\(1)") as A_Program;
+    const statement = ast.body[0];
+
+    expect(statement?.type).toBe("ExpressionStatement");
+    if (statement?.type !== "ExpressionStatement") {
+      throw new Error("expected expression statement");
+    }
+
+    const expression = statement.expression;
+    expect(expression.type).toBe("AssignmentExpression");
+    if (expression.type !== "AssignmentExpression") {
+      throw new Error("expected assignment expression");
+    }
+
+    expect(expression.right.type).toBe("LambdaExpression");
+    expect(expression.right).not.toHaveProperty("scopes");
+  });
+
+  test("parses array elision as null elements", () => {
+    const ast = parse("[,1,,2,]") as A_Program;
+    const statement = ast.body[0];
+
+    expect(statement?.type).toBe("ExpressionStatement");
+    if (statement?.type !== "ExpressionStatement") {
+      throw new Error("expected expression statement");
+    }
+
+    const expression = statement.expression;
+    expect(expression.type).toBe("ArrayExpression");
+    if (expression.type !== "ArrayExpression") {
+      throw new Error("expected array expression");
+    }
+
+    expect(expression.elements).toEqual([
+      null,
+      expect.objectContaining({ type: "Literal", value: 1 }),
+      null,
+      expect.objectContaining({ type: "Literal", value: 2 }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- allow AST literals to represent runtime nil as undefined
- add a parser-only LambdaExpression variant without runtime scopes while preserving the runtime lambda contract
- type parser-emitted array elisions as null elements and cover ConditionalExpression in A_ANY
- add focused AST type/parser contract tests

## Validation
- pnpm test --run src/__tests__/astTypes.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run
- pre-commit hook: lint, test, typecheck

## Review
- deep-review self-review: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the `ast.d.ts` type declarations with shapes the parser actually emits: `A_Literal.value` now allows `undefined` for runtime nil, `A_ArrayExpression.elements` allows `null` entries for array elisions, and a new `A_ParsedLambdaExpression` type splits the parser-time representation (no `scopes`) from the runtime `A_LambdaExpression` (with `scopes`). Focused AST type/parser-contract tests are added to cover all four changes.

- `A_ParsedLambdaExpression` is added to `A_ANY` and handled by `processLambdaExpression`, which always attaches scopes before the lambda is used as a runtime value; existing callers in `processWalk`/`processForEachSlot` that access only `processor.body` are unaffected.
- `null` array-elision elements are safe at runtime because `executor.ts` short-circuits on `!script` and returns `undefined`, matching JS elision semantics.
- `typeGuard.ts` was not updated alongside the new `A_ParsedLambdaExpression` type, leaving `typeGuard.LambdaExpression` narrowing to `A_LambdaExpression` (requires `scopes: T_scope[]`) even for nodes that may only have `scopes?: undefined`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three type changes are consistent with how the runtime processors already handle these values, and the new tests confirm parser output matches the updated declarations.

The undefined literal, null array-elision, and parsed-lambda changes each map cleanly onto existing executor short-circuits and processor logic. No current call site accesses .scopes on a raw parsed node; the only code that spreads left.scopes does so on a runtime value that has already passed through processLambdaExpression. The one gap — typeGuard.ts not being updated — is a type-accuracy concern for future code, not a present defect.

src/typeGuard.ts (not in the diff) should be updated to reflect the new A_ParsedLambdaExpression type so that LambdaExpression narrowing remains accurate as the codebase evolves.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/ast.d.ts | Adds undefined to A_Literal.value, null elements to A_ArrayExpression.elements, and the new A_ParsedLambdaExpression type to A_ANY; all changes are consistent with how processLiteral and processArrayExpression handle these at runtime, though typeGuard.ts was not updated to reflect the new parsed/runtime lambda split. |
| src/__tests__/astTypes.test.ts | New test file with focused type-contract and parser-shape tests covering all four changes: undefined literals, parsed lambdas, null array elision elements, and ConditionalExpression in A_ANY. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Parser["Parser\n(peg.js)"] -->|emits| PLambda["A_ParsedLambdaExpression\n{ type: 'LambdaExpression', body, scopes?: undefined }"]
    PLambda -->|type guard matches 'LambdaExpression'| ProcLambda["processLambdaExpression(script, currentScopes)\n→ { ...script, scopes: currentScopes }"]
    ProcLambda -->|runtime value| RLambda["A_LambdaExpression\n{ type: 'LambdaExpression', body, scopes: T_scope[] }"]
    RLambda -->|used as left in| ME["MemberExpression\nexecute(left.body, [...left.scopes], trace)"]
    Parser -->|emits| ALiteral["A_Literal\n{ type: 'Literal', value: undefined | null | boolean | number | string }"]
    ALiteral --> ProcLit["processLiteral\n→ script.value"]
    Parser -->|emits| AArray["A_ArrayExpression\n{ type: 'ArrayExpression', elements: (A_ANY | null)[] }"]
    AArray --> ProcArr["processArrayExpression\nelements.flatMap(el => [execute(el, ...)])\nnull → execute returns undefined via !script guard"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Parser["Parser\n(peg.js)"] -->|emits| PLambda["A_ParsedLambdaExpression\n{ type: 'LambdaExpression', body, scopes?: undefined }"]
    PLambda -->|type guard matches 'LambdaExpression'| ProcLambda["processLambdaExpression(script, currentScopes)\n→ { ...script, scopes: currentScopes }"]
    ProcLambda -->|runtime value| RLambda["A_LambdaExpression\n{ type: 'LambdaExpression', body, scopes: T_scope[] }"]
    RLambda -->|used as left in| ME["MemberExpression\nexecute(left.body, [...left.scopes], trace)"]
    Parser -->|emits| ALiteral["A_Literal\n{ type: 'Literal', value: undefined | null | boolean | number | string }"]
    ALiteral --> ProcLit["processLiteral\n→ script.value"]
    Parser -->|emits| AArray["A_ArrayExpression\n{ type: 'ArrayExpression', elements: (A_ANY | null)[] }"]
    AArray --> ProcArr["processArrayExpression\nelements.flatMap(el => [execute(el, ...)])\nnull → execute returns undefined via !script guard"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Cover parsed conditional AST type contra..."](https://github.com/xpadev-net/niwango-core.js/commit/f58b1adcdbee0d0bacf3df11e19365bf638f029a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39489991)</sub>

<!-- /greptile_comment -->