### PR TITLE
診断ログの機密情報出力を抑止

### DIFF
--- a/src/__tests__/diagnosticLogging.test.ts
+++ b/src/__tests__/diagnosticLogging.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { prototypeScope } from "@/context";
+import NiwangoCore from "@/main";
+import { parseScript } from "@/parser/parse";
+
+const stringifyArg = (arg: unknown) => {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+};
+
+type ConsoleSpy = {
+  mock: {
+    calls: unknown[][];
+  };
+};
+
+const consoleOutput = (spies: ConsoleSpy[]) =>
+  spies
+    .flatMap((spy) => spy.mock.calls)
+    .map((args) => args.map(stringifyArg).join(" "))
+    .join("\n");
+
+const spyOnDiagnostics = () => [
+  vi.spyOn(console, "info").mockImplementation(() => undefined),
+  vi.spyOn(console, "log").mockImplementation(() => undefined),
+  vi.spyOn(console, "error").mockImplementation(() => undefined),
+  vi.spyOn(console, "debug").mockImplementation(() => undefined),
+];
+
+const executeWithSecretScope = (source: string, secret: string) => {
+  const ast = parseScript(source, "diagnostic.test");
+  return NiwangoCore.execute(
+    ast,
+    [{ secret }, { hostToken: secret }, prototypeScope],
+    [ast],
+  );
+};
+
+describe("diagnostic logging redaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("syntax recovery diagnostics omit the script text", () => {
+    const secret = "SCRIPT_SECRET_PARSE";
+    const spies = spyOnDiagnostics();
+
+    expect(
+      parseScript(`"${secret}"@+1`, "diagnostic.test", {
+        recoverSyntaxErrors: true,
+      }),
+    ).toBeTruthy();
+
+    expect(consoleOutput(spies)).not.toContain(secret);
+    expect(console.info).toHaveBeenCalled();
+  });
+
+  test("caught runtime errors omit AST, scope, and trace secrets", () => {
+    const secret = "RUNTIME_SCOPE_SECRET";
+    const scriptSecret = "RUNTIME_SCRIPT_SECRET";
+    const spies = spyOnDiagnostics();
+
+    expect(executeWithSecretScope(`missing("${scriptSecret}")`, secret)).toBe(
+      undefined,
+    );
+
+    const output = consoleOutput(spies);
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain(scriptSecret);
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("[execute] NotImplementedError"),
+    );
+  });
+
+  test("dump does not write argument values or trace by default", () => {
+    const secret = "DUMP_SCOPE_SECRET";
+    const spies = spyOnDiagnostics();
+
+    expect(executeWithSecretScope("dump(secret)", secret)).toBe(undefined);
+
+    expect(console.debug).not.toHaveBeenCalled();
+    expect(consoleOutput(spies)).not.toContain(secret);
+  });
+
+  test("invalid at-call diagnostics omit trace and scope secrets", () => {
+    const secret = "AT_TRACE_SECRET";
+    const spies = spyOnDiagnostics();
+
+    expect(executeWithSecretScope("@()", secret)).toBe(undefined);
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[call expression] @: at least 1 argument required",
+    );
+    expect(consoleOutput(spies)).not.toContain(secret);
+  });
+});

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -8,6 +8,13 @@ import { TooMuchRecursionError } from "@/errors/TooMuchRecursionError";
 import { processors } from "@/processors";
 import typeGuard from "@/typeGuard";
 
+const formatRuntimeDiagnostic = (error: unknown, traceLength: number) => {
+  if (error instanceof Error) {
+    return `[execute] ${error.name || "Error"} at trace depth ${traceLength}`;
+  }
+  return `[execute] Unknown error at trace depth ${traceLength}`;
+};
+
 /**
  * ASTを実行する関数
  * @param script
@@ -40,9 +47,7 @@ const execute: Execute = (
   } catch (e) {
     if (e instanceof ResourceLimitError) throw e;
     if (!options.catch) throw e;
-    const err = e as Record<string, unknown>;
-    console.log(e, err.ast, err.scopes);
-    console.log("trace", trace);
+    console.log(formatRuntimeDiagnostic(e, trace.length));
   }
   for (const hook of resultHook) {
     result = hook(result);

--- a/src/functions/At.ts
+++ b/src/functions/At.ts
@@ -5,7 +5,7 @@ import { resolve } from "@/utils";
 
 const processAt: IrFunction = (script, scopes, _, trace: A_ANY[]) => {
   if (!script.arguments[0]) {
-    console.error("[call expression] @: at least 1 argument required", trace);
+    console.error("[call expression] @: at least 1 argument required");
     return;
   }
   assign(

--- a/src/functions/dump.ts
+++ b/src/functions/dump.ts
@@ -18,7 +18,7 @@ const processDump: IrFunction = (
   trace: A_ANY[],
 ) => {
   for (const argument of script.arguments) {
-    structuredClone(execute(argument, scopes, trace));
+    execute(argument, scopes, trace);
   }
 };
 

--- a/src/functions/dump.ts
+++ b/src/functions/dump.ts
@@ -17,11 +17,9 @@ const processDump: IrFunction = (
   _object,
   trace: A_ANY[],
 ) => {
-  const arr = [];
   for (const argument of script.arguments) {
-    arr.push(structuredClone(execute(argument, scopes, trace)));
+    structuredClone(execute(argument, scopes, trace));
   }
-  console.debug("%cdump", "background:green;", ...arr, trace);
 };
 
 export { processDump };

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -66,6 +66,14 @@ const assertParserInputLength = (script: string, maxInputLength: number) => {
   }
 };
 
+const formatSyntaxRecoveryDiagnostic = (
+  error: PeggySyntaxError,
+  source: string,
+) => {
+  const location = error.location.start;
+  return `[parse] ${error.name} in ${source}:${location.line}:${location.column}`;
+};
+
 const parseScript = (
   content: string,
   name: string,
@@ -102,7 +110,7 @@ const parseScript = (
       if (recoveryAttempts >= maxRecoveryAttempts) {
         throw new ParserRecoveryLimitError(maxRecoveryAttempts, e);
       }
-      console.info(e.format([{ source: name, text: script }]));
+      console.info(formatSyntaxRecoveryDiagnostic(e, name));
       const removed =
         script.slice(0, e.location.start.offset) +
         script.slice(e.location.start.offset + 1);

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -21,13 +21,7 @@ const assign = (
     resolveReference(target, scopes, trace)?.set(value);
   } catch (e) {
     if (e instanceof Error) {
-      console.error(
-        `[assign] ${e.name}: ${e.message}`,
-        target,
-        value,
-        scopes,
-        trace,
-      );
+      console.error(`[assign] ${e.name} for ${target.type}`);
     }
   }
 };

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -21,7 +21,7 @@ const assign = (
     resolveReference(target, scopes, trace)?.set(value);
   } catch (e) {
     if (e instanceof Error) {
-      console.error(`[assign] ${e.name} for ${target.type}`);
+      console.error(`[assign] ${e.name}: ${e.message} for ${target.type}`);
     }
   }
 };

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -29,7 +29,7 @@ const resolve = (script: A_ANY, scopes: T_scope[], _trace: A_ANY[]) => {
     }
   } catch (e) {
     if (e instanceof Error) {
-      console.error(`[resolve] ${e.name} for ${script.type}`);
+      console.error(`[resolve] ${e.name}: ${e.message} for ${script.type}`);
     }
   }
   return undefined;

--- a/src/utils/resolve.ts
+++ b/src/utils/resolve.ts
@@ -14,7 +14,7 @@ import {
  * @param scopes
  * @param trace
  */
-const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
+const resolve = (script: A_ANY, scopes: T_scope[], _trace: A_ANY[]) => {
   try {
     if (typeGuard.Identifier(script)) {
       const key = normalizeSlotKey(script.name);
@@ -29,7 +29,7 @@ const resolve = (script: A_ANY, scopes: T_scope[], trace: A_ANY[]) => {
     }
   } catch (e) {
     if (e instanceof Error) {
-      console.error(`[resolve] ${e.name}: ${e.message}`, script, scopes, trace);
+      console.error(`[resolve] ${e.name} for ${script.type}`);
     }
   }
   return undefined;


### PR DESCRIPTION
## チケットへのリンク

* z/tasks.md P2: `診断ログから script / scope / trace の漏えいを止める`

## やったこと

* parseScript の syntax recovery ログを script 本文なしの location summary に変更しました。
* catch 有効時の execute 診断ログから AST / scope / trace の生出力を削除し、エラー種別と trace depth のみ出すようにしました。
* assign / resolve / @() のエラーログから runtime object / trace の生出力を削除しました。
* dump() はデフォルトで console 出力しないようにしました。
* parse error / runtime error / dump() / invalid @() が secret を console に出さない回帰テストを追加しました。

## やらないこと

* 広い debug logger API の新設はしません。今回の範囲では既存のデフォルト診断ログの漏えい抑止に限定しています。
* 許可範囲外の既存 console 診断（例: MemberExpression / reference）はこの PR では触りません。

## できるようになること（ユーザ目線）

* 構文エラー復旧、実行時エラー、dump()、invalid @() のデフォルト動作で script / scope / trace / secret が console に出にくくなります。

## できなくなること（ユーザ目線）

* dump() はデフォルトでは console.debug に値を出力しなくなります。
* catch 有効時の execute は console に AST / scope / trace の詳細を出さなくなります。

## 動作確認

* `npm test -- --run src/__tests__/diagnosticLogging.test.ts src/__tests__/parser.test.ts src/__tests__/Execute.test.ts` passed（24 tests）
* `npm test -- --run` passed（18 files / 134 tests）
* `npm run lint` passed
* `npm run check-types` passed
* `pnpm test --run` passed（18 files / 134 tests）
* pre-commit hook: lint / test / typecheck passed

## その他

* Independent review: subagent review completed with no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR redacts sensitive runtime data from niwango-core's default diagnostic logs: script source text, scope values, AST nodes, and trace arrays are no longer emitted to the console. A new regression-test suite verifies that the four affected paths (syntax recovery, caught runtime errors, `dump()`, invalid `@()`) do not expose secrets.

- **`executor.ts` / `parse.ts`**: Replaced verbatim error/AST/scope/trace dumps with terse formatted strings carrying only the error name, source position, or trace depth.
- **`dump.ts`**: Removed `console.debug` output entirely; argument expressions are still executed for side effects (e.g. `dump(x=5)` still assigns `x`).
- **`assign.ts` / `resolve.ts` / `At.ts`**: Dropped `target`, `value`, `scopes`, and `trace` objects from existing error logs; human-readable `e.message` and node `type` strings are retained for debuggability.
</details>

<h3>Confidence Score: 5/5</h3>

All changes are narrow, targeted redactions of log arguments — no logic paths, data flows, or public API contracts are altered.

Every changed call site removes only the sensitive runtime objects from console output while preserving the surrounding logic unchanged. The new test suite directly covers each redacted path and confirms secrets do not appear in captured output. The dump() behaviour change is an intentional, documented breaking change with no impact on execution correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/__tests__/diagnosticLogging.test.ts | New regression suite with four tests covering each changed path. Uses vi.spyOn to intercept all four console methods and asserts secrets never appear in the captured output. |
| src/executor.ts | Replaces the two raw console.log calls (which dumped the full error object, AST, scopes, and trace) with a single formatted string containing only the error name and trace depth. |
| src/parser/parse.ts | formatSyntaxRecoveryDiagnostic replaces the Peggy e.format() call that included the raw script text; output is now source name + line:column only. |
| src/functions/dump.ts | Removes the console.debug call and the now-unnecessary structuredClone wrapper; execute() is still called per argument for side effects. |
| src/utils/assign.ts | Drops target, value, scopes, and trace from the error log; retains e.name, e.message, and target.type. |
| src/utils/resolve.ts | Drops script, scopes, and trace from the error log; trace parameter renamed to _trace to signal intentional non-use. |
| src/functions/At.ts | Removes trace from console.error call; error message text is unchanged. Minimal and correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Diagnostic event] --> B{Which path?}
    B --> C[parse: syntax recovery]
    B --> D[execute: caught runtime error]
    B --> E[dump call]
    B --> F[assign/resolve error]
    B --> G[At call — missing args]

    C --> C1["console.info: error name + source:line:col only"]
    D --> D1["console.log: error name + trace depth only"]
    E --> E1["execute args for side effects — no console output"]
    F --> F1["console.error: name + message + NodeType only"]
    G --> G1["console.error: static message only"]

    style C1 fill:#d4edda,stroke:#28a745
    style D1 fill:#d4edda,stroke:#28a745
    style E1 fill:#d4edda,stroke:#28a745
    style F1 fill:#d4edda,stroke:#28a745
    style G1 fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Diagnostic event] --> B{Which path?}
    B --> C[parse: syntax recovery]
    B --> D[execute: caught runtime error]
    B --> E[dump call]
    B --> F[assign/resolve error]
    B --> G[At call — missing args]

    C --> C1["console.info: error name + source:line:col only"]
    D --> D1["console.log: error name + trace depth only"]
    E --> E1["execute args for side effects — no console output"]
    F --> F1["console.error: name + message + NodeType only"]
    G --> G1["console.error: static message only"]

    style C1 fill:#d4edda,stroke:#28a745
    style D1 fill:#d4edda,stroke:#28a745
    style E1 fill:#d4edda,stroke:#28a745
    style F1 fill:#d4edda,stroke:#28a745
    style G1 fill:#d4edda,stroke:#28a745
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address diagnostic review feedback"](https://github.com/xpadev-net/niwango-core.js/commit/df1c99a54947c19d3cc88ca6e097b6cf7b54aca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39493600)</sub>

<!-- /greptile_comment -->