### PR TITLE
Support logical assignment parsing

### DIFF
--- a/src/__tests__/bug.test.ts
+++ b/src/__tests__/bug.test.ts
@@ -93,3 +93,27 @@ test("logical assignment short-circuits the right side", () => {
     expect(globalScope).toEqual({ hit: 0, value });
   }
 });
+
+test("logical assignment parses and executes from source", () => {
+  expect(run("value=0;hit=0;value ||= (hit=2);hit+':'+value")).toBe("2:2");
+  expect(run("value=1;hit=0;value ||= (hit=2);hit+':'+value")).toBe("0:1");
+
+  expect(run("value=1;hit=0;value &&= (hit=2);hit+':'+value")).toBe("2:2");
+  expect(run("value=0;hit=0;value &&= (hit=2);hit+':'+value")).toBe("0:0");
+
+  expect(run("value=nil;hit=0;value ??= (hit=2);hit+':'+value")).toBe("2:2");
+  expect(run("value=1;hit=0;value ??= (hit=2);hit+':'+value")).toBe("0:1");
+});
+
+test("logical assignment keeps computed member targets single-pass", () => {
+  for (const [script, expected] of [
+    ["i=0;hit=0;a=[1];a[i++] ||= (hit=2);i+':'+hit+':'+a[0]", "1:0:1"],
+    ["i=0;hit=0;a=[0];a[i++] ||= (hit=2);i+':'+hit+':'+a[0]", "1:2:2"],
+    ["i=0;hit=0;a=[0];a[i++] &&= (hit=2);i+':'+hit+':'+a[0]", "1:0:0"],
+    ["i=0;hit=0;a=[1];a[i++] &&= (hit=2);i+':'+hit+':'+a[0]", "1:2:2"],
+    ["i=0;hit=0;a=[1];a[i++] ??= (hit=2);i+':'+hit+':'+a[0]", "1:0:1"],
+    ["i=0;hit=0;a=[nil];a[i++] ??= (hit=2);i+':'+hit+':'+a[0]", "1:2:2"],
+  ] as const) {
+    expect(run(script)).toBe(expected);
+  }
+});

--- a/src/grammar/niwango.pegjs
+++ b/src/grammar/niwango.pegjs
@@ -890,6 +890,9 @@ AssignmentOperator
   / "&="
   / "^="
   / "|="
+  / "&&="
+  / "||="
+  / "??="
 
 Expression
   = head:AssignmentExpression tail:(__ "," __ AssignmentExpression)* {

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -243,6 +243,9 @@ function peg$parse(input, options) {
   const peg$c68 = "&=";
   const peg$c69 = "^=";
   const peg$c70 = "|=";
+  const peg$c71 = "&&=";
+  const peg$c72 = "||=";
+  const peg$c73 = "??=";
 
   const peg$r0 = /^[\t\v-\f \xA0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]/;
   const peg$r1 = /^[\n\r\u2028\u2029]/;
@@ -375,6 +378,9 @@ function peg$parse(input, options) {
   const peg$e102 = peg$literalExpectation("&=", false);
   const peg$e103 = peg$literalExpectation("^=", false);
   const peg$e104 = peg$literalExpectation("|=", false);
+  const peg$e105 = peg$literalExpectation("&&=", false);
+  const peg$e106 = peg$literalExpectation("||=", false);
+  const peg$e107 = peg$literalExpectation("??=", false);
 
   function peg$f0(program) {    return program;  }
   function peg$f1(name) {    return name;  }
@@ -7128,6 +7134,33 @@ function peg$parse(input, options) {
                         } else {
                           s0 = peg$FAILED;
                           if (peg$silentFails === 0) { peg$fail(peg$e104); }
+                        }
+                        if (s0 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 3) === peg$c71) {
+                            s0 = peg$c71;
+                            peg$currPos += 3;
+                          } else {
+                            s0 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$e105); }
+                          }
+                          if (s0 === peg$FAILED) {
+                            if (input.substr(peg$currPos, 3) === peg$c72) {
+                              s0 = peg$c72;
+                              peg$currPos += 3;
+                            } else {
+                              s0 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$e106); }
+                            }
+                            if (s0 === peg$FAILED) {
+                              if (input.substr(peg$currPos, 3) === peg$c73) {
+                                s0 = peg$c73;
+                                peg$currPos += 3;
+                              } else {
+                                s0 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$e107); }
+                              }
+                            }
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
## Summary
- Accept logical assignment operators in the grammar and regenerated parser
- Cover source-level execution for ||=, &&=, and ??=
- Verify computed member targets resolve once while preserving short-circuit RHS behavior

## Validation
- npm run check:parser
- pnpm vitest run src/__tests__/bug.test.ts src/__tests__/LogicalExpression.test.ts src/__tests__/astTypes.test.ts
- npm test -- --run
- npm run lint
- npm run check-types
- pnpm test --run

## Review
- Self-review with deep-review checklist
- Independent subagent review: no actionable findings

Residual risk: the pre-existing AssignmentExpression grammar accepts missing RHS for assignment operators; this task keeps that broader legacy behavior unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the niwango PEG grammar and its generated parser to recognize the three logical assignment operators (`||=`, `&&=`, `??=`) as valid `AssignmentOperator` tokens, enabling scripts to use them from source text rather than only through manually constructed AST nodes.

- **Grammar / parser**: Three new literal alternatives (`&&=`, `||=`, `??=`) are appended to the `AssignmentOperator` rule in `niwango.pegjs`, and the corresponding `parser.js` is regenerated consistently; the ordering does not create ambiguity with the existing `&=` / `|=` alternatives because those two-character literals fail to match a three-character input that starts with `&&` / `||`.
- **Execution layer** (`AssignmentExpression.ts`, pre-existing, not in diff): All three operators already had correct short-circuit guards and `reference.set()` calls in place; the grammar change makes them reachable from source text.
- **Tests**: Two new source-level test cases verify correct short-circuit semantics for simple identifier targets and, importantly, that computed member targets (`a[i++]`) are evaluated only once regardless of whether the assignment proceeds.
</details>

<h3>Confidence Score: 5/5</h3>

This is a purely additive grammar and parser change; no existing parsing rules are altered and the execution path for all previously valid scripts is untouched.

The change is minimal and well-scoped: three new literal alternatives are appended to AssignmentOperator, the execution logic in AssignmentExpression.ts was already correct for these operators, and the two new test cases exercise both identifier and computed-member targets including the single-evaluation invariant. The grammar ordering does not introduce ambiguity with the existing &= / |= alternatives. No regressions to existing functionality are expected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/grammar/niwango.pegjs | Adds `&&=`, `||=`, and `??=` as alternatives in `AssignmentOperator`; PEG ordered-choice semantics mean the shorter `&=`/`|=` entries do not shadow the new 3-character tokens. |
| src/parser/parser.js | Regenerated parser consistently adds `peg$c71/72/73` literals and matching blocks for the three new operators, nested inside the existing `peg$FAILED` chain after `|=`. |
| src/__tests__/bug.test.ts | Adds two new source-level test cases: one covering all three logical-assignment operators on identifier targets, and one confirming computed member targets are evaluated exactly once whether or not the assignment is taken. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse source text] --> B{AssignmentOperator?}
    B -->|"&&= / ||= / ??="| C[Build AssignmentExpression AST node]
    B -->|"other operator"| D[Existing compound/simple assignment]
    C --> E[processAssignmentExpression]
    E --> F[resolveReference left-hand side\nevaluates computed key once]
    F --> G[left = reference.get]
    G --> H{Short-circuit?}
    H -->|"&&= and left is falsy"| I[return left — RHS not evaluated]
    H -->|"||= and left is truthy"| I
    H -->|"??= and left is non-null/undefined"| I
    H -->|No short-circuit| J[execute RHS]
    J --> K[result = processor left right]
    K --> L[reference.set result]
    L --> M[return result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Parse source text] --> B{AssignmentOperator?}
    B -->|"&&= / ||= / ??="| C[Build AssignmentExpression AST node]
    B -->|"other operator"| D[Existing compound/simple assignment]
    C --> E[processAssignmentExpression]
    E --> F[resolveReference left-hand side\nevaluates computed key once]
    F --> G[left = reference.get]
    G --> H{Short-circuit?}
    H -->|"&&= and left is falsy"| I[return left — RHS not evaluated]
    H -->|"||= and left is truthy"| I
    H -->|"??= and left is non-null/undefined"| I
    H -->|No short-circuit| J[execute RHS]
    J --> K[result = processor left right]
    K --> L[reference.set result]
    L --> M[return result]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Support logical assignment parsing"](https://github.com/xpadev-net/niwango-core.js/commit/9f30d002d0df2b60b0f720c9bac9de77537b4810) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39501174)</sub>

<!-- /greptile_comment -->