### PR TITLE
Broaden quality checks and package smoke

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,10 +1,6 @@
 /**
  * Babel Configuration
  */
-module.exports= {
-  presets: [
-    [
-      "@babel/preset-env",
-    ],
-  ],
+module.exports = {
+  presets: [["@babel/preset-env"]],
 };

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -35,6 +35,10 @@ on:
       - ".babelrc.js"
       - ".github/workflows/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,17 +1,47 @@
-name: Typescript Jest
+name: Quality
 
 on:
   push:
     paths:
       - "src/**"
+      - "util/check-workflows.mjs"
+      - "util/generate-parser.js"
+      - "util/package-smoke.mjs"
+      - "util/resolve-path-alias.js"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "biome.json"
+      - "tsconfig*.json"
+      - "rollup.config*.mjs"
+      - "vitest.config.ts"
+      - ".babelrc.js"
+      - ".github/workflows/**"
+  pull_request:
+    branches: [ develop ]
+    paths:
+      - "src/**"
+      - "util/check-workflows.mjs"
+      - "util/generate-parser.js"
+      - "util/package-smoke.mjs"
+      - "util/resolve-path-alias.js"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "biome.json"
+      - "tsconfig*.json"
+      - "rollup.config*.mjs"
+      - "vitest.config.ts"
+      - ".babelrc.js"
+      - ".github/workflows/**"
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  typescript-jest:
-    name: Typescript Jest
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,5 +56,8 @@ jobs:
           npm install -g pnpm
           pnpm install
 
+      - name: Run quality checks
+        run: pnpm lint
+
       - name: Run tests
-        run: pnpm test
+        run: pnpm test --run

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
     "prepack": "npm run build",
     "check-types": "npx tsc --noEmit --jsx react",
+    "check:workflows": "node ./util/check-workflows.mjs",
     "eslint": "biome lint src",
     "eslint:fix": "biome lint --write src",
     "format": "biome format src",
     "format:fix": "biome format --write src",
-    "lint": "biome check src",
-    "lint:fix": "biome check --write --unsafe src",
+    "lint": "npm run check:workflows && biome check src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/package-smoke.mjs && npm run check-types && npm run check:parser && npm run build && npm run smoke:package",
+    "lint:fix": "biome check --write --unsafe src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/package-smoke.mjs",
+    "smoke:package": "node ./util/package-smoke.mjs",
     "prepare": "node -e \"process.exit(process.env.CI?0:1)\" || lefthook install || node -e \"process.exit(0)\"",
     "test": "vitest"
   },
@@ -52,6 +54,7 @@
     "typedoc": "^0.28.10",
     "typedoc-plugin-missing-exports": "^4.1.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "eslint:fix": "biome lint --write src",
     "format": "biome format src",
     "format:fix": "biome format --write src",
-    "lint": "npm run check:workflows && biome check src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/package-smoke.mjs && npm run check-types && npm run check:parser && npm run build && npm run smoke:package",
-    "lint:fix": "biome check --write --unsafe src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/package-smoke.mjs",
+    "lint": "node \"$npm_execpath\" run check:workflows && biome check src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/generate-parser.js util/package-smoke.mjs util/resolve-path-alias.js && node \"$npm_execpath\" run check-types && node \"$npm_execpath\" run check:parser && node \"$npm_execpath\" run build && node \"$npm_execpath\" run smoke:package",
+    "lint:fix": "biome check --write --unsafe src .babelrc.js biome.json package.json pnpm-workspace.yaml tsconfig.json tsconfig.build-dts.json tsconfig.eslint.json vitest.config.ts rollup.config.mjs rollup.config.dts.mjs util/check-workflows.mjs util/generate-parser.js util/package-smoke.mjs util/resolve-path-alias.js",
     "smoke:package": "node ./util/package-smoke.mjs",
     "prepare": "node -e \"process.exit(process.env.CI?0:1)\" || lefthook install || node -e \"process.exit(0)\"",
     "test": "vitest"

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "types": "dist/niwango-core.d.ts",
   "private": false,
   "scripts": {
-    "build": "npx rimraf dist&&npm run build:ts&&npm run build:dts",
+    "build": "npx rimraf dist&&node \"$npm_execpath\" run build:ts&&node \"$npm_execpath\" run build:dts",
     "build:ts": "rollup -c rollup.config.mjs",
     "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&npx copyfiles -u 2 src/parser/*.d.ts dist/dts/parser/&&node ./util/resolve-path-alias.js&&rollup -c rollup.config.dts.mjs",
     "pegjs": "node ./util/generate-parser.js",
-    "check:parser": "npm run pegjs && git diff --exit-code -- src/parser/parser.js src/parser/parser.d.ts && vitest run src/__tests__/parserGeneratedContract.test.ts",
+    "check:parser": "node \"$npm_execpath\" run pegjs && git diff --exit-code -- src/parser/parser.js src/parser/parser.d.ts && vitest run src/__tests__/parserGeneratedContract.test.ts",
     "watch": "rollup -c rollup.config.mjs -w",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
-    "prepack": "npm run build",
+    "prepack": "node \"$npm_execpath\" run build",
     "check-types": "npx tsc --noEmit --jsx react",
     "check:workflows": "node ./util/check-workflows.mjs",
     "eslint": "biome lint src",
@@ -54,7 +54,6 @@
     "typedoc": "^0.28.10",
     "typedoc-plugin-missing-exports": "^4.1.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4",
-    "yaml": "^2.9.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,10 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(yaml@2.8.1)
+        version: 3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -597,24 +600,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.0':
     resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.0':
     resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.0':
     resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.0':
     resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
@@ -947,56 +954,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -1337,11 +1355,12 @@ packages:
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1948,6 +1967,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -2010,6 +2030,11 @@ packages:
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3072,13 +3097,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.2.1)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.2.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.2(@types/node@24.2.1)(yaml@2.8.1)
+      vite: 7.1.2(@types/node@24.2.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3844,13 +3869,13 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite-node@3.2.4(@types/node@24.2.1)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.2.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.2(@types/node@24.2.1)(yaml@2.8.1)
+      vite: 7.1.2(@types/node@24.2.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3865,7 +3890,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.2(@types/node@24.2.1)(yaml@2.8.1):
+  vite@7.1.2(@types/node@24.2.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.4.6(picomatch@4.0.3)
@@ -3876,13 +3901,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.2.1
       fsevents: 2.3.3
-      yaml: 2.8.1
+      yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.2.1)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.2.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3900,8 +3925,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.2(@types/node@24.2.1)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.2.1)(yaml@2.8.1)
+      vite: 7.1.2(@types/node@24.2.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.2.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.2.1
@@ -3973,6 +3998,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.2.1)(jsdom@26.1.0)(yaml@2.9.0)
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
 
 packages:
 
@@ -3999,7 +3996,8 @@ snapshots:
 
   yaml@2.8.1: {}
 
-  yaml@2.9.0: {}
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@20.2.9: {}
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts","src/**/*.tsx", "types/**/*.d.ts","./declaration.d.ts",
-	".eslintrc.cjs"
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "types/**/*.d.ts",
+    "./declaration.d.ts",
+    ".eslintrc.cjs"
   ]
 }

--- a/util/check-workflows.mjs
+++ b/util/check-workflows.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+
+const workflowFiles = fs
+  .readdirSync(workflowsDir)
+  .filter((file) => /\.ya?ml$/u.test(file))
+  .sort();
+
+if (workflowFiles.length === 0) {
+  throw new Error("No GitHub workflow YAML files found");
+}
+
+for (const file of workflowFiles) {
+  const filePath = path.join(workflowsDir, file);
+  const source = fs.readFileSync(filePath, "utf8");
+  const document = parseDocument(source, { prettyErrors: true });
+
+  if (document.errors.length > 0) {
+    const errors = document.errors
+      .map((error) => `${file}: ${error.message}`)
+      .join("\n");
+    throw new Error(errors);
+  }
+
+  const workflow = document.toJSON();
+
+  if (!workflow || typeof workflow !== "object") {
+    throw new Error(`${file}: workflow must be a YAML mapping`);
+  }
+
+  if (typeof workflow.name !== "string" || workflow.name.length === 0) {
+    throw new Error(`${file}: workflow must declare a non-empty name`);
+  }
+
+  if (!("on" in workflow)) {
+    throw new Error(`${file}: workflow must declare triggers`);
+  }
+
+  if (
+    !workflow.jobs ||
+    typeof workflow.jobs !== "object" ||
+    Array.isArray(workflow.jobs)
+  ) {
+    throw new Error(`${file}: workflow must declare jobs as a mapping`);
+  }
+}

--- a/util/check-workflows.mjs
+++ b/util/check-workflows.mjs
@@ -1,7 +1,7 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseDocument } from "yaml";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -20,17 +20,7 @@ if (workflowFiles.length === 0) {
 
 for (const file of workflowFiles) {
   const filePath = path.join(workflowsDir, file);
-  const source = fs.readFileSync(filePath, "utf8");
-  const document = parseDocument(source, { prettyErrors: true });
-
-  if (document.errors.length > 0) {
-    const errors = document.errors
-      .map((error) => `${file}: ${error.message}`)
-      .join("\n");
-    throw new Error(errors);
-  }
-
-  const workflow = document.toJSON();
+  const workflow = parseWorkflow(filePath, file);
 
   if (!workflow || typeof workflow !== "object") {
     throw new Error(`${file}: workflow must be a YAML mapping`);
@@ -40,7 +30,7 @@ for (const file of workflowFiles) {
     throw new Error(`${file}: workflow must declare a non-empty name`);
   }
 
-  if (!("on" in workflow)) {
+  if (!("on" in workflow) && !("true" in workflow)) {
     throw new Error(`${file}: workflow must declare triggers`);
   }
 
@@ -50,5 +40,30 @@ for (const file of workflowFiles) {
     Array.isArray(workflow.jobs)
   ) {
     throw new Error(`${file}: workflow must declare jobs as a mapping`);
+  }
+}
+
+function parseWorkflow(filePath, file) {
+  try {
+    const output = execFileSync(
+      "ruby",
+      [
+        "-ryaml",
+        "-rjson",
+        "-e",
+        "data = YAML.load_file(ARGV.fetch(0)); puts JSON.generate(data)",
+        filePath,
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    return JSON.parse(output);
+  } catch (error) {
+    const message =
+      error.stderr?.toString().trim() || error.message || "unknown error";
+    throw new Error(`${file}: ${message}`);
   }
 }

--- a/util/package-smoke.mjs
+++ b/util/package-smoke.mjs
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+);
+
+const requiredPackageFiles = [pkg.main, pkg.types];
+
+for (const file of requiredPackageFiles) {
+  if (typeof file !== "string" || file.length === 0) {
+    throw new Error("package.json must declare main and types entries");
+  }
+
+  if (!fs.existsSync(path.join(repoRoot, file))) {
+    throw new Error(`Missing built package entry: ${file}`);
+  }
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "niwango-package-"));
+const consumerDir = path.join(tempRoot, "consumer");
+
+const run = (command, args, options = {}) => {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    ...options,
+  });
+};
+
+try {
+  const packOutput = execFileSync(
+    "npm",
+    ["pack", "--json", "--pack-destination", tempRoot, "--ignore-scripts"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    },
+  );
+  const [packInfo] = JSON.parse(packOutput);
+  const packedFiles = new Set(packInfo.files.map((file) => file.path));
+
+  for (const file of requiredPackageFiles) {
+    if (!packedFiles.has(file)) {
+      throw new Error(`Packed package is missing ${file}`);
+    }
+  }
+
+  fs.mkdirSync(consumerDir);
+  fs.writeFileSync(
+    path.join(consumerDir, "package.json"),
+    JSON.stringify({ private: true, type: "commonjs" }, null, 2),
+  );
+
+  const tarball = path.join(tempRoot, packInfo.filename);
+  run(
+    "npm",
+    ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball],
+    {
+      cwd: consumerDir,
+    },
+  );
+
+  fs.writeFileSync(
+    path.join(consumerDir, "require-smoke.cjs"),
+    `
+const exported = require(${JSON.stringify(pkg.name)});
+const NiwangoCore = exported.default ?? exported;
+
+if (typeof NiwangoCore.execute !== "function") {
+  throw new Error("Package main does not expose execute()");
+}
+
+if (typeof NiwangoCore.parse !== "function") {
+  throw new Error("Package main does not expose parse()");
+}
+
+NiwangoCore.parse("1 + 1;");
+`,
+  );
+  run("node", ["require-smoke.cjs"], { cwd: consumerDir });
+
+  fs.writeFileSync(
+    path.join(consumerDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          esModuleInterop: true,
+          skipLibCheck: false,
+        },
+        include: ["type-smoke.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(consumerDir, "type-smoke.ts"),
+    `
+import NiwangoCore from ${JSON.stringify(pkg.name)};
+import type { A_Program, Execute } from ${JSON.stringify(pkg.name)};
+
+const parse: typeof NiwangoCore.parse = NiwangoCore.parse;
+const execute: typeof NiwangoCore.execute = NiwangoCore.execute;
+const typedExecute: Execute = execute;
+const program: A_Program = { type: "Program", body: [] };
+
+const ast = parse("1 + 1;");
+void ast;
+void program;
+void typedExecute;
+`,
+  );
+  run(
+    path.join(repoRoot, "node_modules", ".bin", "tsc"),
+    ["--noEmit", "--project", "tsconfig.json"],
+    {
+      cwd: consumerDir,
+    },
+  );
+} finally {
+  if (process.env.KEEP_PACKAGE_SMOKE !== "1") {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  } else {
+    console.log(`Kept package smoke temp dir: ${tempRoot}`);
+  }
+}


### PR DESCRIPTION
## Summary
- expand `lint` to validate workflow YAML, config files, type checking, parser generated contract, build, and package smoke
- add package smoke that packs the built package, installs it in a temp consumer, checks the declared runtime entrypoint, and type-checks public imports/types
- update the Quality workflow to run the same lint contract and tests for source/config/package/workflow changes

## Validation
- npm run lint
- npm run check-types
- npm run check:parser
- npm run build && npm run smoke:package
- npm test -- --run
- pnpm test --run

## Review
- deep-review self-pass completed
- independent automation/package-smoke review found workflow YAML and path-filter gaps; both were fixed and revalidated

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR broadens the CI quality gate from a simple Jest run into a full pipeline: workflow YAML validation, biome linting of all config/util files, type checking, parser contract verification, build, and a package smoke test. The `package-smoke.mjs` script packs the tarball, installs it in a throw-away consumer, and verifies both the CJS runtime interface (`execute`/`parse`) and the TypeScript public type surface (`A_Program`, `Execute`).

- **`util/check-workflows.mjs`** — new script that validates every `.github/workflows/*.yml` file for required `name`, trigger, and `jobs` keys using Ruby's YAML parser; handles both old (YAML 1.1 `on` → `true`) and modern Ruby behavior.
- **`util/package-smoke.mjs`** — new end-to-end consumer test: packs with `npm pack`, installs the tarball in a temp dir, exercises a CJS `require()` check, then runs `tsc --noEmit` against a generated `type-smoke.ts` that imports public types with `skipLibCheck: false`.
- **`package.json` / `.github/workflows/jest.yml`** — `lint` now chains all quality checks using `node \"$npm_execpath\"` for package-manager agnosticism; the workflow gains a `pull_request` trigger targeting `develop`, a broader `paths` filter, and a `concurrency` group to cancel duplicate runs.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are developer tooling and CI configuration with no impact on the published runtime.

All seven changed files are CI workflow, build scripts, and formatter config. The new utility scripts are defensive (they throw on unexpected state, clean up in finally, and are guarded by pre-checks on dist/ existence). The only notable wrinkle is an implicit Ruby dependency in check-workflows.mjs, which is a local-dev portability concern rather than a correctness issue.

util/check-workflows.mjs — relies on Ruby being present in the execution environment, which is undocumented.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| util/check-workflows.mjs | New script that validates every workflow YAML for required keys (name, on/true, jobs). Uses Ruby to parse YAML — a non-obvious external dependency that could cause confusing errors in Ruby-less environments. |
| util/package-smoke.mjs | New package smoke script: packs the built tarball, installs it in a temp consumer, validates CJS require of execute/parse, and type-checks public imports/types against A_Program and Execute. Cleanup via finally block is correct. |
| .github/workflows/jest.yml | Renamed to Quality; broadened push path-filter to cover config/util/workflow files; added pull_request trigger targeting develop; added concurrency group to cancel duplicate runs; now runs pnpm lint before tests. |
| package.json | Replaces bare npm run sub-invocations with node "$npm_execpath" run for package-manager agnosticism; expands lint to run check:workflows + biome + check-types + check:parser + build + smoke:package; adds check:workflows and smoke:package scripts. |
| pnpm-lock.yaml | Bumps yaml peer dep from 2.8.1 to 2.9.0 (vite optional dep), adds libc field to Linux platform-specific Biome/Rollup binary entries. |
| tsconfig.eslint.json | Formatting-only change: reformatted include array to multi-line style and added missing newline at end of file. |
| .babelrc.js | Minor style fix: added missing space after = and collapsed nested preset array to one-liner; no functional change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm lint] --> B[check:workflows\nRuby YAML parse + validate]
    A --> C[biome check\nsrc + all config/util files]
    A --> D[check-types\ntsc --noEmit]
    A --> E[check:parser\nregenerate + git diff + contract test]
    A --> F[build\nrollup ts + dts]
    F --> G[smoke:package\npackage-smoke.mjs]
    G --> H[npm pack --json]
    H --> I[Verify main + types in packed files]
    I --> J[npm install tarball in temp consumer]
    J --> K[node require-smoke.cjs\nverify execute + parse at runtime]
    J --> L[tsc --noEmit type-smoke.ts\nverify A_Program + Execute types]
    B --> |uses| M[ruby -ryaml -rjson]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm lint] --> B[check:workflows\nRuby YAML parse + validate]
    A --> C[biome check\nsrc + all config/util files]
    A --> D[check-types\ntsc --noEmit]
    A --> E[check:parser\nregenerate + git diff + contract test]
    A --> F[build\nrollup ts + dts]
    F --> G[smoke:package\npackage-smoke.mjs]
    G --> H[npm pack --json]
    H --> I[Verify main + types in packed files]
    I --> J[npm install tarball in temp consumer]
    J --> K[node require-smoke.cjs\nverify execute + parse at runtime]
    J --> L[tsc --noEmit type-smoke.ts\nverify A_Program + Execute types]
    B --> |uses| M[ruby -ryaml -rjson]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Remove workflow parser dependency"](https://github.com/xpadev-net/niwango-core.js/commit/4f43cc3e379472b80e4bc61df63d2b76a6d274e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39502247)</sub>

<!-- /greptile_comment -->